### PR TITLE
docs: align stale docs and quickstart with current API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
           python examples/billing_demo.py
           python examples/http_driver_demo.py
           python examples/tutorial.py
+          python examples/readme_quickstart.py
 
   conformance_stub:
     name: "Weaver Spec Conformance Stub (v0.1.0)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   yields `Frame` chunks; the last chunk carries `is_final=True`. Drivers
   without `execute_stream` automatically fall back to a single-chunk stream
   via `execute()`. `Frame` gained an `is_final: bool` field. (#47)
+- `examples/readme_quickstart.py` — a runnable mirror of the README quickstart,
+  wired into `make example` and the CI "Examples" step so the first code a new
+  user runs cannot silently drift from the working API. (#83)
 
 ### Changed
 - Tech debt: `policy_dsl.py` decomposed (was 661 lines). Parsing and
@@ -73,9 +76,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `from agent_kernel import Kernel` / `from agent_kernel.kernel import Kernel`
   imports are unchanged. (#68)
 
+### Documentation
+- Fixed handle-expansion examples that omitted the now-required `principal`
+  argument and therefore raised `HandleConstraintViolation` when copy-pasted:
+  the README quickstart (#83) and `docs/context_firewall.md` +
+  `docs/architecture.md` (#84) now pass `principal=` and link to
+  `docs/security.md#handle-expansion-boundary`. The README quickstart also
+  drops two unused imports (`ExecutionContext`, `HMACTokenProvider`).
+- `docs/capabilities.md` "Sensitivity tags" now lists `SensitivityTag.MEMORY`
+  and links to `docs/security.md#memory-actions`. (#89)
+- Corrected the base-dependency list in `docs/agent-context/invariants.md` and
+  `docs/agent-context/architecture.md` from "`httpx` only" to
+  "`httpx` + `pydantic`", pointing to `AGENTS.md` as the canonical dependency
+  policy. (#90)
+- The `agent_kernel` module docstring's `Errors::` block now lists every
+  exported error class — added `TokenRevoked`, `AdapterParseError`,
+  `CapabilityAlreadyRegistered`, `HandleConstraintViolation`,
+  `ManifestSignatureError`, and `DiscoveryError`. (#91)
+
 ### Tests
 - Added explicit dry-run regression tests for `HTTPDriver` and `MCPDriver`,
   pinning the kernel's driver-agnostic dry-run short-circuit. (#68)
+- `tests/test_public_api.py` — asserts every error class exported via `__all__`
+  appears in the `agent_kernel` module docstring, preventing public-API
+  docstring drift. (#91)
 
 ### Fixed
 - `merge_sensitivity()` (and `most_restrictive` imports) now ranks the `MEMORY`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,8 +56,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   without `execute_stream` automatically fall back to a single-chunk stream
   via `execute()`. `Frame` gained an `is_final: bool` field. (#47)
 - `examples/readme_quickstart.py` — a runnable mirror of the README quickstart,
-  wired into `make example` and the CI "Examples" step as a regression guard: CI
-  fails if the documented flow ever stops working against the API. (#83)
+  wired into `make example` and the CI "Examples" step. Together with
+  `tests/test_readme_quickstart.py` (which extracts and runs the inline README
+  snippet itself), CI fails if the documented quickstart stops producing the
+  expected output. (#83)
 
 ### Changed
 - Tech debt: `policy_dsl.py` decomposed (was 661 lines). Parsing and
@@ -100,6 +102,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `tests/test_public_api.py` — asserts every error class exported via `__all__`
   appears in the `agent_kernel` module docstring, preventing public-API
   docstring drift. (#91)
+- `tests/test_readme_quickstart.py` — extracts the README quickstart code block
+  and executes it, asserting the documented output so the inline snippet cannot
+  silently drift from the working API. (#83)
 
 ### Fixed
 - `merge_sensitivity()` (and `most_restrictive` imports) now ranks the `MEMORY`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,8 +56,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   without `execute_stream` automatically fall back to a single-chunk stream
   via `execute()`. `Frame` gained an `is_final: bool` field. (#47)
 - `examples/readme_quickstart.py` — a runnable mirror of the README quickstart,
-  wired into `make example` and the CI "Examples" step so the first code a new
-  user runs cannot silently drift from the working API. (#83)
+  wired into `make example` and the CI "Examples" step as a regression guard: CI
+  fails if the documented flow ever stops working against the API. (#83)
 
 ### Changed
 - Tech debt: `policy_dsl.py` decomposed (was 661 lines). Parsing and

--- a/Makefile
+++ b/Makefile
@@ -17,5 +17,6 @@ example:
 	python examples/billing_demo.py
 	python examples/http_driver_demo.py
 	python examples/tutorial.py
+	python examples/readme_quickstart.py
 
 ci: fmt lint type test example

--- a/README.md
+++ b/README.md
@@ -50,10 +50,9 @@ import asyncio, os
 os.environ["AGENT_KERNEL_SECRET"] = "my-secret"
 
 from agent_kernel import (
-    Capability, CapabilityRegistry, HMACTokenProvider,
+    Capability, CapabilityRegistry,
     InMemoryDriver, Kernel, Principal, SafetyClass, StaticRouter,
 )
-from agent_kernel.drivers.base import ExecutionContext
 from agent_kernel.models import CapabilityRequest
 
 # 1. Register a capability
@@ -86,7 +85,11 @@ async def main():
     print(frame.facts)           # ['Total rows: 1', 'Top keys: id, title', ...]
     print(frame.handle)          # Handle(handle_id='...', ...)
 
-    expanded = kernel.expand(frame.handle, query={"limit": 1, "fields": ["title"]})
+    # `principal` is required: the handle is bound to the granting principal,
+    # so an omitted principal raises HandleConstraintViolation.
+    expanded = kernel.expand(
+        frame.handle, query={"limit": 1, "fields": ["title"]}, principal=principal
+    )
     print(expanded.table_preview)  # [{'title': 'Buy milk'}]
 
     trace = kernel.explain(frame.action_id)
@@ -94,6 +97,10 @@ async def main():
 
 asyncio.run(main())
 ```
+
+> The runnable version of this quickstart lives at
+> [`examples/readme_quickstart.py`](examples/readme_quickstart.py) and is exercised by
+> `make example` / CI, so this snippet cannot silently drift from the working API.
 
 ## Where it fits
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,9 @@ asyncio.run(main())
 
 > The runnable version of this quickstart lives at
 > [`examples/readme_quickstart.py`](examples/readme_quickstart.py) and is exercised by
-> `make example` / CI, so this snippet cannot silently drift from the working API.
+> `make example` / CI, which fails if the documented flow ever regresses against the
+> API. CI runs that mirror but does not diff this inline snippet against it, so the two
+> are kept in step by hand.
 
 ## Where it fits
 

--- a/README.md
+++ b/README.md
@@ -98,11 +98,11 @@ async def main():
 asyncio.run(main())
 ```
 
-> The runnable version of this quickstart lives at
-> [`examples/readme_quickstart.py`](examples/readme_quickstart.py) and is exercised by
-> `make example` / CI, which fails if the documented flow ever regresses against the
-> API. CI runs that mirror but does not diff this inline snippet against it, so the two
-> are kept in step by hand.
+> This snippet is extracted and executed by CI (`tests/test_readme_quickstart.py`), and
+> a standalone runnable mirror lives at
+> [`examples/readme_quickstart.py`](examples/readme_quickstart.py) (run by `make example`).
+> CI fails if either stops producing the documented output, so this quickstart cannot
+> silently drift from the working API.
 
 ## Where it fits
 

--- a/docs/agent-context/architecture.md
+++ b/docs/agent-context/architecture.md
@@ -39,7 +39,7 @@ The architecture optimizes for:
 | Tokens signed, not encrypted | Simplicity; avoids key management complexity | Payloads are readable — never store secrets in them |
 | Keyword-based capability search | Deterministic; no external service dependency | Less flexible than semantic search; relies on good tagging |
 | Firewall is mandatory | Prevents accidental context blowup and data leakage | All output is bounded; debugging requires admin `raw` mode |
-| Single dep (`httpx` only) | Minimal attack surface for a security kernel | Adding a dependency requires justification |
+| Minimal deps (`httpx` + `pydantic`) | Small attack surface for a security kernel | Adding a dependency requires justification (see `AGENTS.md`) |
 
 ## Things not to simplify
 

--- a/docs/agent-context/invariants.md
+++ b/docs/agent-context/invariants.md
@@ -40,7 +40,8 @@ These constraints are non-negotiable. Violating any one silently degrades securi
    derived keys must stay out of logs, error messages, and traces.
 
 6. **Never add dependencies without justification.** The dependency list is intentionally
-   minimal (`httpx` only). Every new dependency expands the attack surface.
+   minimal (`httpx` + `pydantic` — see [`AGENTS.md`](../../AGENTS.md) for the canonical
+   dependency policy). Every new dependency expands the attack surface.
 
 7. **Never register duplicate capability IDs.** The registry raises
    `CapabilityAlreadyRegistered`. Duplicates cause ambiguous routing and policy

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -31,7 +31,7 @@ The central orchestrator. Wires all components together and exposes:
 - `request_capabilities(goal)` — discover relevant capabilities
 - `grant_capability(request, principal, justification)` — policy check + token issuance
 - `invoke(token, principal, args, response_mode, dry_run=False)` — execute + firewall + trace, or short-circuit before driver dispatch when `dry_run=True`
-- `expand(handle, query)` — paginate/filter stored results
+- `expand(handle, *, query, principal=None)` — paginate/filter stored results; `principal` is required for principal-bound handles (see [`docs/security.md`](security.md#handle-expansion-boundary))
 - `explain(action_id)` — retrieve audit trace
 - `explain_denial(request, principal, justification)` — return a structured `DenialExplanation` instead of raising `PolicyDenied`
 

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -83,6 +83,10 @@ Each capability should map to a single, auditable action with clear side-effects
 Use `SensitivityTag.PII` when results may contain: name, email, phone, SSN, address.
 Use `SensitivityTag.PCI` when results may contain: card numbers, CVV, bank details.
 Use `SensitivityTag.SECRETS` when results may contain: API keys, passwords, tokens.
+Use `SensitivityTag.MEMORY` when results are durable agent memory (project notes,
+session handoff, learned context). Pair it with the `memory.read` / `memory.write` /
+`memory.forget` capability IDs to activate the policy rules and audit-trace redaction
+described in [`docs/security.md#memory-actions`](security.md#memory-actions).
 
 Always pair sensitivity tags with `allowed_fields` to restrict which fields are returned
 to non-privileged callers.

--- a/docs/context_firewall.md
+++ b/docs/context_firewall.md
@@ -32,18 +32,23 @@ Budgets(
 
 A `Handle` is an opaque reference to the full dataset stored server-side.
 
+A handle is bound to the principal it was granted to, so `expand()` requires that
+same `principal` — an omitted or mismatched principal raises
+`HandleConstraintViolation` (handle IDs are not bearer credentials). See
+[`docs/security.md#handle-expansion-boundary`](security.md#handle-expansion-boundary).
+
 ```python
 # Stored automatically on every invoke()
 handle = frame.handle
 
 # Expand with pagination
-expanded = kernel.expand(handle, query={"offset": 10, "limit": 5})
+expanded = kernel.expand(handle, query={"offset": 10, "limit": 5}, principal=principal)
 
 # Field selection
-expanded = kernel.expand(handle, query={"fields": ["id", "name"]})
+expanded = kernel.expand(handle, query={"fields": ["id", "name"]}, principal=principal)
 
 # Basic filtering
-expanded = kernel.expand(handle, query={"filter": {"status": "unpaid"}})
+expanded = kernel.expand(handle, query={"filter": {"status": "unpaid"}}, principal=principal)
 ```
 
 ## Redaction

--- a/examples/readme_quickstart.py
+++ b/examples/readme_quickstart.py
@@ -1,0 +1,79 @@
+"""readme_quickstart.py — runnable mirror of the README "Quickstart".
+
+Kept in step with the quickstart in ``README.md`` so CI catches regressions in
+the first code a new user runs (issue #83). ``make example`` and the CI
+"Examples" step execute this file; the final ``assert`` fails the build if
+handle expansion ever stops returning the documented result.
+
+Run with: ``python examples/readme_quickstart.py``
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+os.environ.setdefault("AGENT_KERNEL_SECRET", "readme-quickstart-secret-not-for-prod")
+
+from agent_kernel import (
+    Capability,
+    CapabilityRegistry,
+    InMemoryDriver,
+    Kernel,
+    Principal,
+    SafetyClass,
+    StaticRouter,
+)
+from agent_kernel.models import CapabilityRequest
+
+# 1. Register a capability
+registry = CapabilityRegistry()
+registry.register(
+    Capability(
+        capability_id="tasks.list",
+        name="List Tasks",
+        description="List all tasks",
+        safety_class=SafetyClass.READ,
+        tags=["tasks", "list"],
+    )
+)
+
+# 2. Wire up a driver
+driver = InMemoryDriver()
+driver.register_handler("tasks.list", lambda ctx: [{"id": 1, "title": "Buy milk"}])
+
+# 3. Build the kernel
+kernel = Kernel(registry=registry, router=StaticRouter(routes={"tasks.list": ["memory"]}))
+kernel.register_driver(driver)
+
+
+async def main() -> None:
+    principal = Principal(principal_id="alice", roles=["reader"])
+
+    # 4. Discover → grant → invoke → expand → explain
+    token = kernel.get_token(
+        CapabilityRequest(capability_id="tasks.list", goal="list tasks"),
+        principal,
+        justification="",
+    )
+    frame = await kernel.invoke(token, principal=principal, args={})
+    print(frame.facts)
+    print(frame.handle)
+
+    # `principal` is required: the handle is bound to the granting principal,
+    # so an omitted principal raises HandleConstraintViolation (#83).
+    expanded = kernel.expand(
+        frame.handle, query={"limit": 1, "fields": ["title"]}, principal=principal
+    )
+    print(expanded.table_preview)
+    assert expanded.table_preview == [{"title": "Buy milk"}], (
+        f"README quickstart regression: expected [{{'title': 'Buy milk'}}], "
+        f"got {expanded.table_preview!r}"
+    )
+
+    trace = kernel.explain(frame.action_id)
+    print(trace.driver_id)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/agent_kernel/__init__.py
+++ b/src/agent_kernel/__init__.py
@@ -40,11 +40,14 @@ Errors::
 
     from agent_kernel import (
         AgentKernelError,
-        TokenExpired, TokenInvalid, TokenScopeError,
-        PolicyDenied, PolicyConfigError, DriverError, FirewallError,
+        TokenExpired, TokenInvalid, TokenScopeError, TokenRevoked,
+        PolicyDenied, PolicyConfigError,
+        DriverError, FirewallError, AdapterParseError,
         BudgetExhausted, BudgetConfigError,
-        CapabilityNotFound, HandleNotFound, HandleExpired,
-        NamespaceNotFound, FederationError, ManifestError, TrustPolicyError,
+        CapabilityNotFound, CapabilityAlreadyRegistered,
+        HandleNotFound, HandleExpired, HandleConstraintViolation,
+        NamespaceNotFound, FederationError, ManifestError, ManifestSignatureError,
+        TrustPolicyError, DiscoveryError,
     )
 """
 

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -8,6 +8,8 @@ class, not a stale subset (issue #91).
 
 from __future__ import annotations
 
+import re
+
 import agent_kernel
 from agent_kernel.errors import AgentKernelError
 
@@ -25,7 +27,12 @@ def _exported_error_names() -> list[str]:
 def test_all_exported_errors_listed_in_module_docstring() -> None:
     """Every exported error class appears in the module docstring."""
     doc = agent_kernel.__doc__ or ""
-    missing = [name for name in _exported_error_names() if name not in doc]
+    # Use word-boundary matching so a shorter name (e.g. ``ManifestError``) is
+    # not falsely considered present merely because it is a contiguous
+    # substring of a longer listed name (e.g. ``ManifestSomethingError``).
+    missing = [
+        name for name in _exported_error_names() if not re.search(rf"\b{re.escape(name)}\b", doc)
+    ]
     assert missing == [], (
         f"Error classes exported in __all__ but absent from the agent_kernel "
         f"module docstring's 'Errors::' block: {missing}. Add them in "

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1,0 +1,33 @@
+"""Public API consistency tests.
+
+Pins the contract that the ``agent_kernel`` module docstring's ``Errors::``
+block stays in sync with the error classes actually exported via ``__all__``.
+A newcomer who reads ``help(agent_kernel)`` should see every public error
+class, not a stale subset (issue #91).
+"""
+
+from __future__ import annotations
+
+import agent_kernel
+from agent_kernel.errors import AgentKernelError
+
+
+def _exported_error_names() -> list[str]:
+    """Return every name in ``__all__`` that is an exported error class."""
+    names: list[str] = []
+    for name in agent_kernel.__all__:
+        obj = getattr(agent_kernel, name)
+        if isinstance(obj, type) and issubclass(obj, AgentKernelError):
+            names.append(name)
+    return names
+
+
+def test_all_exported_errors_listed_in_module_docstring() -> None:
+    """Every exported error class appears in the module docstring."""
+    doc = agent_kernel.__doc__ or ""
+    missing = [name for name in _exported_error_names() if name not in doc]
+    assert missing == [], (
+        f"Error classes exported in __all__ but absent from the agent_kernel "
+        f"module docstring's 'Errors::' block: {missing}. Add them in "
+        f"src/agent_kernel/__init__.py so help(agent_kernel) stays accurate."
+    )

--- a/tests/test_readme_quickstart.py
+++ b/tests/test_readme_quickstart.py
@@ -1,0 +1,53 @@
+"""README quickstart consistency test.
+
+Extracts the Quickstart code block from ``README.md`` and runs it so CI fails
+if the inline snippet ever stops producing the result a new user is told to
+expect (issue #83). This guards the *inline* README snippet directly, alongside
+``examples/readme_quickstart.py`` (the standalone runnable mirror executed by
+``make example``).
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_README = _REPO_ROOT / "README.md"
+_EXPECTED_OUTPUT = "[{'title': 'Buy milk'}]"
+
+
+def _extract_quickstart_snippet() -> str:
+    """Return the README ``python`` block that holds the quickstart flow."""
+    blocks = re.findall(
+        r"```python\n(.*?)```", _README.read_text(encoding="utf-8"), flags=re.DOTALL
+    )
+    for block in blocks:
+        if "asyncio.run(main())" in block and "kernel.expand(" in block:
+            return block
+    raise AssertionError(
+        "Could not locate the Quickstart python block (containing "
+        "'asyncio.run(main())' and 'kernel.expand(') in README.md."
+    )
+
+
+def test_readme_quickstart_runs_and_matches_documented_output() -> None:
+    """The README quickstart snippet runs and prints the documented preview."""
+    snippet = _extract_quickstart_snippet()
+    result = subprocess.run(
+        [sys.executable, "-c", snippet],
+        capture_output=True,
+        text=True,
+        cwd=_REPO_ROOT,
+        timeout=60,
+    )
+    assert result.returncode == 0, (
+        "README quickstart snippet failed to execute.\n"
+        f"--- stdout ---\n{result.stdout}\n--- stderr ---\n{result.stderr}"
+    )
+    assert _EXPECTED_OUTPUT in result.stdout, (
+        f"README quickstart output drifted: expected {_EXPECTED_OUTPUT!r} in "
+        f"stdout.\n--- stdout ---\n{result.stdout}"
+    )


### PR DESCRIPTION
## What changed

Five documentation-drift fixes where canonical docs no longer matched the code (one coherent "documentation truth-up" change):

- **#83 — README quickstart** (`README.md`): added the now-required `principal=principal` to `kernel.expand()` (it raised `HandleConstraintViolation` when copy-pasted), and dropped two unused imports (`ExecutionContext`, `HMACTokenProvider`). Added a runnable, asserting mirror at `examples/readme_quickstart.py`, wired into `make example` (`Makefile`) and the CI "Examples" step (`.github/workflows/ci.yml`) so the snippet can't silently drift again.
- **#84 — canonical firewall/architecture docs** (`docs/context_firewall.md`, `docs/architecture.md`): the three `expand()` snippets and the method-list signature now pass `principal=` and link to `docs/security.md#handle-expansion-boundary`.
- **#89 — capability docs** (`docs/capabilities.md`): the "Sensitivity tags" section now lists `SensitivityTag.MEMORY` and links to `docs/security.md#memory-actions`.
- **#90 — dependency policy** (`docs/agent-context/invariants.md`, `docs/agent-context/architecture.md`): corrected "`httpx` only" → "`httpx` + `pydantic`", pointing to `AGENTS.md` as the single canonical dependency policy.
- **#91 — public API docstring** (`src/agent_kernel/__init__.py`): the module docstring's `Errors::` block now lists every exported error class (added `TokenRevoked`, `AdapterParseError`, `CapabilityAlreadyRegistered`, `HandleConstraintViolation`, `ManifestSignatureError`, `DiscoveryError`). Added `tests/test_public_api.py` to guard against future drift.
- `CHANGELOG.md`: `[Unreleased]` entries for the above.

## Why

All five issues are the same bug category — docs/docstrings that drifted from the current code (notably the `expand()` principal-binding from #76 and the `MEMORY` tag / `pydantic` base dep that shipped later). #83 is the first code a new user runs, so it was the highest-impact (P0). Per `AGENTS.md`, code is authoritative over docs and `CHANGELOG.md` is updated in the same change.

## How verified

`make ci` passes end-to-end. Explicit results:

- `ruff check src/ tests/ examples/` — All checks passed!
- `ruff format --check src/ tests/ examples/` — 67 files already formatted (no diff)
- `mypy src/` — Success: no issues found in 41 source files
- `python -m pytest -q` — **559 passed, 1 skipped**
- `tests/test_public_api.py` — fails before the `__init__.py` fix (lists the 6 missing error names), passes after
- Reproduced #83 directly: the old snippet raised `HandleConstraintViolation: ... cannot be expanded by '<unspecified>'`; the fixed snippet prints `[{'title': 'Buy milk'}]` (now asserted by `examples/readme_quickstart.py`, run by `make example` + CI)
- Confirmed every doc link target exists: `docs/security.md` has `## Handle expansion boundary` and `## Memory actions`; `../../AGENTS.md` resolves from `docs/agent-context/`

## Tradeoffs / risks

- Doc-only behavior, plus one new example and one new test — no library API or behavior change.
- The README inline snippet and `examples/readme_quickstart.py` are intentionally kept in step; the example's assertion is the regression guard if they ever diverge.

## Scope notes (Mode B)

Scope is the recommended combined-PR group from the triage report (#83, #84, #89, #90, #91). Two **Mode B** correctness extensions beyond the literal issue text, both directly supporting the issues' own optional acceptance criteria:

1. #83 also removes the unused `HMACTokenProvider` import (issue only named `ExecutionContext`) so the runnable example lints clean.
2. Added `examples/readme_quickstart.py` (#83) and `tests/test_public_api.py` (#91) as regression guards — both were suggested as optional in the issues.

Not included: the build/foundation group (#85 version drift, #86/#88 Makefile, #87 mcp mypy) and the ecosystem-integration group (#92–#96), which are separate concerns.

Closes #83, #84, #89, #90, #91.

https://claude.ai/code/session_01Wu4wPXHDwzPqTFvra7Rkzz

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wu4wPXHDwzPqTFvra7Rkzz)_