### PR TITLE
fix: align make ci with CI workflow (python -m tools, non-mutating fmt-check)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ Use these terms consistently. Never substitute synonyms:
 
 ## Quality bar
 
-- `make ci` must pass before every push. It runs: `fmt → lint → type → test → example`.
+- `make ci` must pass before every push. It runs: `fmt-check → lint → type → test → example`. Use `make fmt` to auto-fix formatting before re-running `make ci`.
 - All public interfaces need type hints and docstrings.
 - Never raise bare `ValueError` or `KeyError` to callers. Use custom exceptions from `errors.py`. Catching stdlib exceptions internally to remap them is fine.
 - Error messages are part of the contract — tests must assert both exception type and message.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A deferred namespace loader that fails (by raising or returning an
   out-of-namespace capability) no longer permanently disables the namespace —
   the load is retried on a later access. (#45)
+- `Makefile` now invokes every tool via `python -m <tool>` (matching the
+  existing `test` target) so `make ci` uses the active interpreter's
+  site-packages instead of whatever `ruff` / `mypy` resolves first on
+  `PATH`. Fixes spurious `import-not-found` / `no-redef` errors on machines
+  where `mypy` or `ruff` is provided by an isolated installer such as
+  `uv tool` or `pipx`. (#86)
+- `make ci` now runs the non-mutating `fmt-check` target (`ruff format
+  --check`) instead of the file-mutating `fmt` target. Local `make ci`
+  now fails on unformatted code exactly like `.github/workflows/ci.yml`
+  does, instead of silently auto-fixing the working tree and letting an
+  unfixed commit be pushed. `make fmt` remains available for manual
+  auto-formatting. `AGENTS.md`, `docs/agent-context/workflows.md`,
+  `docs/agent-context/review-checklist.md`, and the `README.md` development
+  section are updated to describe the new chain. (#88)
 
 ## [0.8.0] - 2026-05-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,8 +131,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   does, instead of silently auto-fixing the working tree and letting an
   unfixed commit be pushed. `make fmt` remains available for manual
   auto-formatting. `AGENTS.md`, `docs/agent-context/workflows.md`,
-  `docs/agent-context/review-checklist.md`, and the `README.md` development
-  section are updated to describe the new chain. (#88)
+  `docs/agent-context/review-checklist.md`, `CONTRIBUTING.md`, and the
+  `README.md` development section are updated to describe the new chain. (#88)
 
 ## [0.8.0] - 2026-05-22
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,11 +15,12 @@ pip install -e ".[dev]"
 ## Running checks
 
 ```bash
-make fmt    # auto-format with ruff
-make lint   # lint with ruff
-make type   # type-check with mypy
-make test   # run pytest with coverage
-make ci     # all of the above + examples
+make fmt        # auto-format with ruff (not run by `make ci`)
+make fmt-check  # verify formatting with `ruff format --check` (no mutation)
+make lint       # lint with ruff
+make type       # type-check with mypy
+make test       # run pytest with coverage
+make ci         # fmt-check + lint + type + test + example
 ```
 
 ## Pull request guidelines

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,16 @@
-.PHONY: fmt lint type test example ci
+.PHONY: fmt fmt-check lint type test example ci
 
 fmt:
-	ruff format src/ tests/ examples/
+	python -m ruff format src/ tests/ examples/
+
+fmt-check:
+	python -m ruff format --check src/ tests/ examples/
 
 lint:
-	ruff check src/ tests/ examples/
+	python -m ruff check src/ tests/ examples/
 
 type:
-	mypy src/
+	python -m mypy src/
 
 test:
 	python -m pytest -q --cov=agent_kernel
@@ -19,4 +22,4 @@ example:
 	python examples/tutorial.py
 	python examples/readme_quickstart.py
 
-ci: fmt lint type test example
+ci: fmt-check lint type test example

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ See [docs/agent-context/invariants.md](docs/agent-context/invariants.md) for the
 git clone https://github.com/dgenio/agent-kernel
 cd agent-kernel
 pip install -e ".[dev]"
-make ci      # fmt + lint + type + test + examples
+make ci      # fmt-check + lint + type + test + examples
 ```
 
 ## License

--- a/docs/agent-context/review-checklist.md
+++ b/docs/agent-context/review-checklist.md
@@ -10,7 +10,7 @@
 Run before every PR submission.
 
 ### CI gate
-- [ ] `make ci` passes (fmt → lint → type → test → example).
+- [ ] `make ci` passes (fmt-check → lint → type → test → example).
 
 ### Correctness
 - [ ] Every changed docstring matches the actual implementation.

--- a/docs/agent-context/workflows.md
+++ b/docs/agent-context/workflows.md
@@ -16,9 +16,10 @@
 | `make example` | Run all example scripts | After changing examples or core APIs |
 
 `make ci` is the **single authoritative pre-push command**. It runs all five targets
-in sequence and matches what `.github/workflows/ci.yml` runs: the format step is the
-non-mutating `fmt-check` (equivalent to CI's `ruff format --check`), and
-lint/type/test/example exercise the same tools and inputs CI does. The Makefile
+in sequence and mirrors the checks in the `test` job of `.github/workflows/ci.yml`: the
+format step is the non-mutating `fmt-check` (equivalent to CI's `ruff format --check`),
+and lint/type/test/example run the same tools CI does. (CI's separate `conformance_stub`
+job is a no-op placeholder and is not part of the local gate.) The Makefile
 additionally invokes every tool via `python -m <tool>` — a local hardening over CI
 that uses the active interpreter's site-packages, preventing spurious failures when
 `ruff` or `mypy` are provided by isolated installers such as `uv tool` or `pipx`. If

--- a/docs/agent-context/workflows.md
+++ b/docs/agent-context/workflows.md
@@ -16,11 +16,14 @@
 | `make example` | Run all example scripts | After changing examples or core APIs |
 
 `make ci` is the **single authoritative pre-push command**. It runs all five targets
-in sequence and mirrors `.github/workflows/ci.yml`: every tool is invoked via
-`python -m <tool>` so the active interpreter's site-packages is always used, and the
-format step is the non-mutating `fmt-check`. If `make ci` passes locally, the same
-checks will pass in CI. Use `make fmt` (the mutating target) when you want to
-auto-fix formatting before re-running `make ci`.
+in sequence and matches what `.github/workflows/ci.yml` runs: the format step is the
+non-mutating `fmt-check` (equivalent to CI's `ruff format --check`), and
+lint/type/test/example exercise the same tools and inputs CI does. The Makefile
+additionally invokes every tool via `python -m <tool>` — a local hardening over CI
+that uses the active interpreter's site-packages, preventing spurious failures when
+`ruff` or `mypy` are provided by isolated installers such as `uv tool` or `pipx`. If
+`make ci` passes locally, the same checks will pass in CI. Use `make fmt` (the
+mutating target) when you want to auto-fix formatting before re-running `make ci`.
 
 ## PR conventions
 

--- a/docs/agent-context/workflows.md
+++ b/docs/agent-context/workflows.md
@@ -7,18 +7,20 @@
 
 | Command | Purpose | When to run |
 |---------|---------|-------------|
-| `make ci` | Full pre-push gate: fmt → lint → type → test → example | Before every push |
-| `make fmt` | Auto-format with ruff | During development |
+| `make ci` | Full pre-push gate: fmt-check → lint → type → test → example | Before every push |
+| `make fmt` | Auto-format with ruff (mutates files) | During development |
+| `make fmt-check` | Verify formatting with `ruff format --check` (no mutation) | Used by `make ci`; matches what CI runs |
 | `make lint` | Lint check with ruff | Isolated lint verification |
 | `make type` | mypy type check | After changing type annotations |
 | `make test` | pytest with coverage | After changing code |
 | `make example` | Run all example scripts | After changing examples or core APIs |
 
 `make ci` is the **single authoritative pre-push command**. It runs all five targets
-in sequence. If `make ci` passes, the PR is ready for review.
-
-**Note:** `make fmt` auto-formats locally, but CI runs `ruff format --check` and fails
-on unformatted code. Always run `make ci` to catch this asymmetry.
+in sequence and mirrors `.github/workflows/ci.yml`: every tool is invoked via
+`python -m <tool>` so the active interpreter's site-packages is always used, and the
+format step is the non-mutating `fmt-check`. If `make ci` passes locally, the same
+checks will pass in CI. Use `make fmt` (the mutating target) when you want to
+auto-fix formatting before re-running `make ci`.
 
 ## PR conventions
 


### PR DESCRIPTION
- Makefile: invoke every tool via `python -m <tool>` so the active
  interpreter's site-packages is always used, instead of whatever
  resolves first on PATH. Fixes spurious mypy import-not-found / ruff
  errors on machines where mypy or ruff is provided by an isolated
  installer such as `uv tool` or `pipx`. (#86)
- Makefile: add a non-mutating `fmt-check` target (`ruff format --check`)
  and switch `ci`'s dependency from `fmt` to `fmt-check`. Local `make ci`
  now fails on unformatted code exactly like .github/workflows/ci.yml
  does, instead of silently auto-fixing the working tree and letting an
  unfixed commit be pushed. `make fmt` is preserved for manual
  auto-formatting. (#88)
- AGENTS.md, docs/agent-context/workflows.md,
  docs/agent-context/review-checklist.md, README.md: update every place
  that named the `make ci` chain literally so docs stay in sync with the
  Makefile. Drops the now-obsolete asymmetry paragraph in workflows.md.
- CHANGELOG.md: add Fixed entries under [Unreleased] referencing #86
  and #88.