### PR TITLE
fix: stop __version__ drift (#85) and mypy [no-redef] in optional mcp import (#87)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   auto-formatting. `AGENTS.md`, `docs/agent-context/workflows.md`,
   `docs/agent-context/review-checklist.md`, `CONTRIBUTING.md`, and the
   `README.md` development section are updated to describe the new chain. (#88)
+- `agent_kernel.__version__` is now derived from the installed distribution
+  metadata (`importlib.metadata.version("weaver-kernel")`) instead of a
+  hand-maintained literal, so it can no longer drift from `pyproject.toml`
+  (it previously reported `0.5.0` while the package shipped `0.7.0`/`0.8.0`).
+  Falls back to `0.0.0+local` in a source tree without dist metadata. (#85)
+- The `mcp.shared.exceptions.McpError` optional import in `drivers/mcp.py`
+  no longer triggers a mypy `[no-redef]` error when the `mcp` extra is not
+  installed. The lazy import is resolved through a `_load_mcp_error()` helper
+  (mirroring `mcp_support.import_optional`), declaring the `_McpError` global
+  exactly once. (#87)
 
 ## [0.8.0] - 2026-05-22
 

--- a/src/agent_kernel/__init__.py
+++ b/src/agent_kernel/__init__.py
@@ -51,6 +51,9 @@ Errors::
     )
 """
 
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
+
 from .adapters import AnthropicMiddleware, OpenAIMiddleware
 from .drivers.base import Driver, ExecutionContext
 from .drivers.http import HTTPDriver
@@ -139,7 +142,13 @@ from .router import StaticRouter
 from .tokens import CapabilityToken, HMACTokenProvider
 from .trace import TraceStore
 
-__version__ = "0.5.0"
+# Single source of truth: read the version from the installed distribution
+# metadata (the PyPI dist name is ``weaver-kernel``, distinct from the import
+# name ``agent_kernel``) so it never drifts from ``pyproject.toml``.
+try:
+    __version__ = _pkg_version("weaver-kernel")
+except PackageNotFoundError:  # pragma: no cover - source tree without dist metadata
+    __version__ = "0.0.0+local"
 
 __all__ = [
     # version

--- a/src/agent_kernel/drivers/mcp.py
+++ b/src/agent_kernel/drivers/mcp.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib
 from collections.abc import Awaitable, Callable
 from typing import Any
 
@@ -19,15 +20,29 @@ from .mcp_support import (
     normalize_call_result,
 )
 
-# Lazy import of McpError — only available when the mcp optional dep is installed.
-# If mcp is absent, factory methods raise ImportError before any session is created,
-# so _McpError will never be None on a live driver instance. The explicit annotation
-# keeps mypy --strict happy across the try/except branches.
-_McpError: type[BaseException] | None
-try:
-    from mcp.shared.exceptions import McpError as _McpError
-except ImportError:  # pragma: no cover
-    _McpError = None
+
+def _load_mcp_error() -> type[BaseException] | None:
+    """Return the ``McpError`` type, or ``None`` when ``mcp`` is unavailable.
+
+    Imported via ``importlib`` (matching ``mcp_support.import_optional``) so the
+    optional-dependency branch is testable. Resolving the type into a separate,
+    explicitly annotated module global avoids the mypy ``[no-redef]`` that the
+    old ``import ... as _McpError`` pattern produced when ``mcp`` was absent and
+    the import resolved to ``Any`` under ``ignore_missing_imports``.
+    """
+    try:
+        exceptions = importlib.import_module("mcp.shared.exceptions")
+    except ImportError:
+        return None
+    error_type: type[BaseException] = exceptions.McpError
+    return error_type
+
+
+# Resolved once at import time and used in _run_with_retries to classify
+# protocol-level rejections as non-retryable. None when the optional ``mcp``
+# dependency is not installed (factory methods raise ImportError first, so this
+# is never None on a live driver instance).
+_McpError: type[BaseException] | None = _load_mcp_error()
 
 
 def _infer_safety_class(spec: ToolSpec) -> SafetyClass:

--- a/src/agent_kernel/drivers/mcp.py
+++ b/src/agent_kernel/drivers/mcp.py
@@ -34,8 +34,14 @@ def _load_mcp_error() -> type[BaseException] | None:
         exceptions = importlib.import_module("mcp.shared.exceptions")
     except ImportError:
         return None
-    error_type: type[BaseException] = exceptions.McpError
-    return error_type
+    # Guard attribute access too: if the module imports but ``McpError`` is
+    # missing or renamed, degrade to ``None`` (matching the old
+    # ``from ... import McpError`` ImportError fallback) rather than raising
+    # AttributeError at import time and breaking the whole driver module.
+    error_type = getattr(exceptions, "McpError", None)
+    if isinstance(error_type, type) and issubclass(error_type, BaseException):
+        return error_type
+    return None
 
 
 # Resolved once at import time and used in _run_with_retries to classify

--- a/tests/test_mcp_driver.py
+++ b/tests/test_mcp_driver.py
@@ -102,6 +102,22 @@ def test_load_mcp_error_returns_none_when_mcp_unavailable() -> None:
         assert _load_mcp_error() is None
 
 
+def test_load_mcp_error_returns_none_when_attribute_missing() -> None:
+    """_load_mcp_error degrades to None if the module imports but McpError is gone.
+
+    Guards against an AttributeError at import time (and a broken driver module)
+    when a future/renamed mcp release no longer exposes ``McpError``.
+    """
+    from types import ModuleType
+
+    from agent_kernel.drivers.mcp import _load_mcp_error
+
+    empty_module = ModuleType("mcp.shared.exceptions")
+    with patch("agent_kernel.drivers.mcp.importlib.import_module") as import_module:
+        import_module.return_value = empty_module
+        assert _load_mcp_error() is None
+
+
 @pytest.mark.asyncio
 async def test_discover_converts_tools_to_capabilities() -> None:
     session = _FakeSession(

--- a/tests/test_mcp_driver.py
+++ b/tests/test_mcp_driver.py
@@ -84,6 +84,24 @@ def test_from_http_missing_dependency_raises_helpful_import_error() -> None:
             MCPDriver.from_http("http://localhost:8080/mcp")
 
 
+def test_load_mcp_error_returns_type_when_mcp_available() -> None:
+    """_load_mcp_error resolves the real McpError type when mcp is installed."""
+    from mcp.shared.exceptions import McpError
+
+    from agent_kernel.drivers.mcp import _load_mcp_error
+
+    assert _load_mcp_error() is McpError
+
+
+def test_load_mcp_error_returns_none_when_mcp_unavailable() -> None:
+    """_load_mcp_error returns None when the optional mcp dep is missing (issue #87)."""
+    from agent_kernel.drivers.mcp import _load_mcp_error
+
+    with patch("agent_kernel.drivers.mcp.importlib.import_module") as import_module:
+        import_module.side_effect = ImportError("No module named 'mcp'")
+        assert _load_mcp_error() is None
+
+
 @pytest.mark.asyncio
 async def test_discover_converts_tools_to_capabilities() -> None:
     session = _FakeSession(

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -9,14 +9,56 @@ distribution name is ``weaver-kernel``, distinct from the import name
 
 from __future__ import annotations
 
+import re
 from importlib.metadata import version as pkg_version
+from pathlib import Path
+
+import pytest
 
 import agent_kernel
 
+_PYPROJECT = Path(__file__).resolve().parent.parent / "pyproject.toml"
+
+
+def _declared_pyproject_version() -> str | None:
+    """Return ``[project].version`` from ``pyproject.toml``, or None if absent.
+
+    Parsed with a small regex rather than ``tomllib`` so the test runs
+    unchanged on Python 3.10 (where ``tomllib`` is unavailable) without adding
+    a ``tomli`` dependency. Returns None when the source tree — and thus
+    ``pyproject.toml`` — is not present (e.g. a wheel-only install).
+    """
+    if not _PYPROJECT.is_file():
+        return None
+    text = _PYPROJECT.read_text(encoding="utf-8")
+    # Scope to the [project] table: from its header up to the next table header.
+    section = re.search(r"(?ms)^\[project\]\s*$(.*?)(?=^\[)", text)
+    body = section.group(1) if section else text
+    match = re.search(r'(?m)^\s*version\s*=\s*"([^"]+)"', body)
+    return match.group(1) if match else None
+
 
 def test_version_matches_distribution_metadata() -> None:
-    """``__version__`` equals the installed ``weaver-kernel`` dist version."""
+    """``__version__`` equals the installed ``weaver-kernel`` dist version.
+
+    Pins that ``__version__`` is *derived from* dist metadata (not a literal);
+    cross-checking against ``pyproject.toml`` is done separately below.
+    """
     assert agent_kernel.__version__ == pkg_version("weaver-kernel")
+
+
+def test_version_matches_pyproject_declaration() -> None:
+    """``__version__`` matches the version declared in ``pyproject.toml``.
+
+    Directly enforces issue #85's acceptance criterion ("matches
+    ``pyproject.toml``'s ``[project].version``") rather than only re-deriving
+    from the same metadata source, so a release that bumps ``pyproject.toml``
+    without refreshing the installed/editable metadata is caught.
+    """
+    declared = _declared_pyproject_version()
+    if declared is None:
+        pytest.skip("pyproject.toml not present (installed without source tree)")
+    assert agent_kernel.__version__ == declared
 
 
 def test_version_is_exported() -> None:

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,24 @@
+"""Version-consistency tests.
+
+Pins the contract that ``agent_kernel.__version__`` is derived from the
+installed distribution metadata rather than a hand-maintained literal, so it
+can never drift from ``pyproject.toml`` again (issue #85). The PyPI
+distribution name is ``weaver-kernel``, distinct from the import name
+``agent_kernel``.
+"""
+
+from __future__ import annotations
+
+from importlib.metadata import version as pkg_version
+
+import agent_kernel
+
+
+def test_version_matches_distribution_metadata() -> None:
+    """``__version__`` equals the installed ``weaver-kernel`` dist version."""
+    assert agent_kernel.__version__ == pkg_version("weaver-kernel")
+
+
+def test_version_is_exported() -> None:
+    """``__version__`` stays part of the public API surface."""
+    assert "__version__" in agent_kernel.__all__


### PR DESCRIPTION
Fixes #85 and #87 — the two remaining infra/correctness defects from the `#85`–`#88` triage batch (the other two, #86 and #88, were already fixed in `d83609d`).

## What changed

**#85 — `agent_kernel.__version__` drifted from `pyproject.toml`**
- `src/agent_kernel/__init__.py`: `__version__` is now derived from installed distribution metadata via `importlib.metadata.version("weaver-kernel")` (single source of truth), with a `PackageNotFoundError` → `"0.0.0+local"` fallback for source trees without dist metadata. The hardcoded `"0.5.0"` literal is gone.
- `tests/test_version.py` (new): asserts `__version__ == importlib.metadata.version("weaver-kernel")` and that `__version__` stays in `__all__`.

**#87 — optional `McpError` import triggered mypy `[no-redef]` when `mcp` was absent**
- `src/agent_kernel/drivers/mcp.py`: replaced the annotate-then-`import ... as _McpError` pattern with a `_load_mcp_error()` helper that imports through `importlib.import_module` (mirroring the existing `mcp_support.import_optional` idiom). `_McpError` is now declared exactly once, so the `[no-redef]` is gone.
- `tests/test_mcp_driver.py`: added two regression tests covering both branches of `_load_mcp_error` (mcp present → returns `McpError`; mcp absent → returns `None`).

**Docs**
- `CHANGELOG.md`: added `### Fixed` entries for #85 and #87 under `[Unreleased]`, matching the existing issue-referenced style.

## Why
- #85: `__version__` reported `0.5.0` while the package shipped `0.7.0`/`0.8.0`. `RELEASE.md` only ever documented bumping `pyproject.toml`, so the literal was a latent drift bug; deriving from metadata aligns the code with the documented release process and makes future drift impossible.
- #87: the old pattern declared `_McpError` twice (annotation + `import as`), which mypy reads as a redefinition once the `mcp` import resolves to `Any` under `ignore_missing_imports` (i.e. on a base install without the `[mcp]` extra).

## How verified
All commands run in a clean dev venv (`pip install -e ".[dev,mcp]"`):

- **Reproduced before fixing:**
  - #85: `metadata: 0.8.0 | module: 0.5.0`
  - #87 (with `mcp` uninstalled): `mcp.py:28: error: Name "_McpError" already defined on line 26 [no-redef]`
- **After fix:**
  - #85: `metadata: 0.8.0 | module: 0.8.0`
  - #87: `python -m mypy src/agent_kernel/drivers/mcp.py` → `Success` **both with and without** the `mcp` extra installed.
- **`make ci`** → exit 0: `ruff format --check` clean, `ruff check` `All checks passed!`, `mypy` `Success: no issues found in 41 source files`, **564 passed / 1 skipped**, coverage 94%, examples ran.
- New tests: `tests/test_version.py` (2) + `_load_mcp_error` cases (2) all pass; the mcp-absent branch is covered.

## Scope notes (Mode B)
Strictly limited to #85 and #87. Diffstat: 5 files, +62/−10 (4 tracked + 1 new test). No back-compat shims (per request — none needed; both are internal/diagnostic surfaces). Other open triage issues (#92–#96, #99, #94) are independent feature/docs work and intentionally not bundled here.

## Risks / caveats
- `importlib.metadata.version()` must use the **distribution** name (`weaver-kernel`), not the import name (`agent_kernel`) — handled and covered by `test_version.py`. In an uninstalled raw source tree the value is `0.0.0+local`; in editable/CI installs it reflects the real dist version.

https://claude.ai/code/session_0185WabrTuoL3jCNZiER7ES6

---
_Generated by [Claude Code](https://claude.ai/code/session_0185WabrTuoL3jCNZiER7ES6)_