### PR TITLE
docs: link the Weaver Stack overview article (Towards AI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Coverage ≥90%](https://img.shields.io/badge/coverage-%E2%89%A590%25-brightgreen.svg)](https://github.com/dgenio/agent-kernel/actions/workflows/ci.yml)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
+[![Read the Weaver Stack overview on Towards AI](https://img.shields.io/badge/Read_the_overview-Towards_AI-black?logo=medium&logoColor=white)](https://pub.towardsai.net/the-weaver-stack-one-contract-layer-for-safe-llm-agents-7f733cad5eac)
 
 <!-- The coverage badge shows the CI-enforced floor (cov_fail_under in
 pyproject.toml). The live figure (well above the floor) prints in every CI run


### PR DESCRIPTION
Adds a **Read the overview on Towards AI** badge to the README's badge row, linking the Weaver Stack pillar article so repo visitors can find the narrative context — why the stack exists and how the layers compose.

README only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
