### PR TITLE
chore(deps): harden Dependabot grouping policy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,12 @@ updates:
         update-types:
           - minor
           - patch
+    # MCP v2 is a deliberate integration migration tracked in #263, not
+    # routine dependency maintenance.
+    ignore:
+      - dependency-name: mcp
+        update-types:
+          - version-update:semver-major
     labels:
       - dependencies
     commit-message:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,28 +1,63 @@
 version: 2
 updates:
-  # Python dependencies. The library declares *ranged* requirements
-  # (httpx>=0.27, pydantic>=2) on purpose; Dependabot only proposes a change
-  # when a dependency drifts out of the declared range, so it never forces a
-  # pin on the library itself. Minor/patch bumps are grouped to limit noise.
+  # Python dependencies. The library declares ranged requirements on purpose;
+  # routine minor/patch updates are grouped, while major compatibility changes
+  # stay separate and explicit.
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: "weekly"
+      day: monday
+      time: "06:00"
+      timezone: Etc/UTC
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
     groups:
-      python-minor-and-patch:
+      python-nonmajor:
+        applies-to: version-updates
+        patterns:
+          - "*"
         update-types:
-          - "minor"
-          - "patch"
+          - minor
+          - patch
+      python-security-nonmajor:
+        applies-to: security-updates
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+    labels:
+      - dependencies
+    commit-message:
+      prefix: "chore(deps)"
 
-  # GitHub Actions. Keeps the SHA-pinned actions in ci.yml / publish.yml /
-  # codeql.yml fresh (it updates the pin and the version comment together).
+  # GitHub Actions are SHA-pinned in workflows. Dependabot advances the pin and
+  # version comment; unrelated breaking majors are intentionally not grouped.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+      day: monday
+      time: "06:00"
+      timezone: Etc/UTC
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
     groups:
-      github-actions:
+      actions-nonmajor:
+        applies-to: version-updates
         patterns:
           - "*"
+        update-types:
+          - minor
+          - patch
+      actions-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+    labels:
+      - dependencies
+    commit-message:
+      prefix: "chore(ci)"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,13 +58,15 @@ dev = [
     "ruff>=0.4",
     "mypy>=1.10",
     "httpx>=0.27",
-    "mcp>=1.6",
+    # MCP 2.x removes/changes APIs used by the current driver. Keep v1 as the
+    # supported compatibility line until the deliberate migration in #263.
+    "mcp>=1.6,<2",
     "pyyaml>=6.0",
     "tomli>=2.0; python_version<'3.11'",
     "types-PyYAML>=6.0",
     "weaver-contracts>=0.7,<0.8",
 ]
-mcp = ["mcp>=1.6"]
+mcp = ["mcp>=1.6,<2"]
 otel = ["opentelemetry-api>=1.20"]
 policy = [
     "pyyaml>=6.0",


### PR DESCRIPTION
## What changed

- add a seven-day cooldown and explicit labels/commit prefixes
- keep routine Python minor/patch updates grouped
- add a separate security-update group
- replace the catch-all GitHub Actions group with non-major and security groups, leaving unrelated major upgrades separate
- keep MCP on the supported `>=1.6,<2` compatibility line and ignore MCP semver-major updates in Dependabot until #263 lands

## Why

Agent-kernel already SHA-pins its workflow dependencies and uses ranged library requirements. The remaining automation risk was policy-level: a catch-all Action group could hide multiple breaking upgrades inside one PR, while security updates were not grouped explicitly.

Validation also exposed a live compatibility problem unrelated to the policy diff: fresh installs resolved MCP Python SDK 2.0.0 under the previous `mcp>=1.6` range, breaking five MCP-driver tests due to v2 API changes. That migration is now tracked explicitly in #263 instead of being allowed to break routine installs.

## Validation

The exact PR head passes the full CI workflow and CodeQL after applying the MCP v1 compatibility ceiling.