### PR TITLE
fix(deps): block MCP v2 range widening in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,12 +28,14 @@ updates:
         update-types:
           - minor
           - patch
-    # MCP v2 is a deliberate integration migration tracked in #263, not
-    # routine dependency maintenance.
+    # MCP v2 is a deliberate integration migration tracked in #263. Ignore
+    # the incompatible versions themselves: Dependabot can otherwise widen a
+    # requirement range (<2 -> <3) without treating that edit as a SemVer-major
+    # version update.
     ignore:
       - dependency-name: mcp
-        update-types:
-          - version-update:semver-major
+        versions:
+          - ">=2,<3"
     labels:
       - dependencies
     commit-message:


### PR DESCRIPTION
Correct the MCP v2 guard added in #262.

Dependabot can widen a manifest requirement (`mcp>=1.6,<2` → `<3`) without treating that manifest edit as a SemVer-major dependency update, so `ignore.update-types: version-update:semver-major` did not stop #264.

Ignore the incompatible MCP versions directly with the package-manager range `>=2,<3`. The deliberate v2 migration remains tracked in #263.