### PR TITLE
feat: add coding-agent least-privilege flagship policy and demo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ example:
 	python examples/http_driver_demo.py
 	python examples/tutorial.py
 	python examples/readme_quickstart.py
+	python examples/coding_agent_least_privilege.py
 	python examples/contextweaver_policy_flow.py
 	python examples/repository_safety_check.py
 	python examples/chainweaver_flow.py

--- a/docs/coding-agent-security.md
+++ b/docs/coding-agent-security.md
@@ -1,0 +1,101 @@
+# Least privilege for coding agents
+
+`weaver-kernel` can give a coding agent useful repository and shell authority
+without turning that authority into an ambient "do anything" permission.
+
+The maintained flagship demo is network-free and makes no real repository or
+GitHub changes:
+
+```bash
+python -m pip install weaver-kernel
+# From a source checkout of the matching release/commit:
+python examples/coding_agent_least_privilege.py
+```
+
+Expected semantic receipt:
+
+```text
+ALLOW repo.read.files README.md
+ALLOW repo.write.files src/demo.py
+DENY repo.write.files .github/workflows/release.yml
+DENY secrets.read .env
+ALLOW shell.run.tests command_class=test
+DENY github.create_pr task=ISSUE-253 before approval
+ALLOW github.create_pr task=ISSUE-253 after task-bound approval
+DENY scope substitution src/demo.py -> .github/workflows/release.yml at execution
+TRACE repo.read.files principal=coder driver=coding-agent
+PASS: useful coding work stays usable while sensitive authority stays explicit.
+```
+
+CI runs that exact demo and the script drift-checks the receipt against
+`examples/coding_agent_expected.txt`.
+
+## Capability vocabulary
+
+The built-in `CodingAgentPolicyEngine` intentionally starts small:
+
+| Capability | Default boundary |
+| --- | --- |
+| `repo.read.files` | normal paths allowed; secret-like paths require `secrets.read` |
+| `repo.write.files` | requires `code_writer`; only configured source/test/docs globs |
+| `shell.run.tests` | requires `test_runner`; only configured test command classes |
+| `shell.run.networked_command` | separately requires `network_runner` |
+| `secrets.read` | separately requires `secrets_reader` |
+| `github.create_pr` | requires an approval attribute bound to the exact task ID |
+| `github.merge_pr` | separately requires `admin` |
+
+This split is deliberate: permission to edit code does not imply permission to
+read credentials, access the network, create organizational work, or merge it.
+
+## Signed scope, not grant-time theatre
+
+A path check that happens only when the token is issued is insufficient. An
+agent could ask for a token scoped to `src/app.py` and then try to invoke the
+same capability with `.github/workflows/release.yml`.
+
+`CodingAgentPolicyEngine` therefore puts the exact approved scope under the
+signed token's `coding_agent` constraints. The execution-side driver calls:
+
+```python
+from weaver_kernel.coding_agent import enforce_coding_agent_constraints
+
+enforce_coding_agent_constraints(ctx.constraints, ctx.args)
+```
+
+If actual invocation arguments differ from the signed grant scope, execution
+fails closed. The flagship demo tests this substitution explicitly.
+
+The host is responsible for supplying normalized, trustworthy request scope
+(e.g. the actual repository-relative path or task ID) and the driver is
+responsible for calling the execution-side constraint helper before the side
+effect. Do not derive the trusted scope from LLM prose.
+
+## Three practical authority profiles
+
+You do not need three policy engines. Keep one policy and change which narrow
+roles/approvals the principal carries for the current phase:
+
+- **Review:** no `code_writer` / `test_runner`; read normal repository files.
+- **Edit + test:** add `code_writer` and `test_runner`; writes remain limited to
+  configured path globs and shell authority remains the test category.
+- **Publish for review:** add a one-task `approved_task_id` attribute to permit
+  `github.create_pr`. This still does **not** grant merge authority.
+
+Use a fresh/task-scoped principal or equivalent session claims when moving
+between phases; do not accumulate permissions indefinitely.
+
+## What this is not
+
+- It is an **embedded authorization boundary** for actions your runtime routes
+  through `weaver-kernel`; it is not a VM/container sandbox.
+- It does not make the LLM trustworthy or prevent prompt injection. It limits
+  what a successful injection can do through mediated capabilities.
+- Drivers that ignore signed constraints can undermine scoped grants. Use the
+  provided helper (or an equivalently strict driver-specific check) before the
+  side effect.
+- If you only need a coarse external policy proxy around MCP traffic rather
+  than an embedded capability runtime, AgentFence may be the simpler boundary.
+
+For the general capability model see [Capabilities](capabilities.md); for hard
+runtime invariants see [Security](security.md) and
+[Agent-context invariants](agent-context/invariants.md).

--- a/examples/coding_agent_expected.txt
+++ b/examples/coding_agent_expected.txt
@@ -1,0 +1,10 @@
+ALLOW repo.read.files README.md
+ALLOW repo.write.files src/demo.py
+DENY repo.write.files .github/workflows/release.yml
+DENY secrets.read .env
+ALLOW shell.run.tests command_class=test
+DENY github.create_pr task=ISSUE-253 before approval
+ALLOW github.create_pr task=ISSUE-253 after task-bound approval
+DENY scope substitution src/demo.py -> .github/workflows/release.yml at execution
+TRACE repo.read.files principal=coder driver=coding-agent
+PASS: useful coding work stays usable while sensitive authority stays explicit.

--- a/examples/coding_agent_least_privilege.py
+++ b/examples/coding_agent_least_privilege.py
@@ -114,7 +114,7 @@ async def invoke_allowed(
 async def main() -> None:
     """Run the maintained ALLOW / DENY / escalation / anti-swap receipt."""
     kernel = build_kernel()
-    coder = Principal(principal_id="coder")
+    coder = Principal(principal_id="coder", roles=["code_writer", "test_runner"])
     receipt: list[str] = []
 
     _, read_frame = await invoke_allowed(
@@ -180,6 +180,7 @@ async def main() -> None:
 
     approved_coder = Principal(
         principal_id="coder",
+        roles=list(coder.roles),
         attributes={"approved_task_id": task_id},
     )
     await invoke_allowed(

--- a/examples/coding_agent_least_privilege.py
+++ b/examples/coding_agent_least_privilege.py
@@ -12,11 +12,24 @@ from __future__ import annotations
 
 import asyncio
 import os
+from pathlib import Path
 
 os.environ.setdefault("WEAVER_KERNEL_SECRET", "coding-agent-demo-not-for-production")
 
-from weaver_kernel import Capability, CapabilityRegistry, InMemoryDriver, Kernel, Principal, SafetyClass, SensitivityTag, StaticRouter
-from weaver_kernel.coding_agent import CodingAgentPolicyEngine, enforce_coding_agent_constraints
+from weaver_kernel import (
+    Capability,
+    CapabilityRegistry,
+    InMemoryDriver,
+    Kernel,
+    Principal,
+    SafetyClass,
+    SensitivityTag,
+    StaticRouter,
+)
+from weaver_kernel.coding_agent import (
+    CodingAgentPolicyEngine,
+    enforce_coding_agent_constraints,
+)
 from weaver_kernel.drivers.base import ExecutionContext
 from weaver_kernel.errors import DriverError, PolicyDenied
 from weaver_kernel.models import CapabilityRequest
@@ -30,6 +43,7 @@ CAPABILITIES: tuple[tuple[str, SafetyClass, SensitivityTag], ...] = (
     ("github.create_pr", SafetyClass.WRITE, SensitivityTag.NONE),
     ("github.merge_pr", SafetyClass.DESTRUCTIVE, SensitivityTag.NONE),
 )
+EXPECTED_RECEIPT = Path(__file__).with_name("coding_agent_expected.txt")
 
 
 def build_kernel() -> Kernel:
@@ -73,6 +87,12 @@ def request(capability_id: str, **scope: str) -> CapabilityRequest:
     )
 
 
+def record(receipt: list[str], line: str) -> None:
+    """Append one stable proof line and display it."""
+    receipt.append(line)
+    print(line)
+
+
 async def invoke_allowed(
     kernel: Kernel,
     principal: Principal,
@@ -95,6 +115,7 @@ async def main() -> None:
     """Run the maintained ALLOW / DENY / escalation / anti-swap receipt."""
     kernel = build_kernel()
     coder = Principal(principal_id="coder")
+    receipt: list[str] = []
 
     _, read_frame = await invoke_allowed(
         kernel,
@@ -103,7 +124,7 @@ async def main() -> None:
         path="README.md",
         justification="Review the repository README",
     )
-    print("ALLOW repo.read.files README.md")
+    record(receipt, "ALLOW repo.read.files README.md")
 
     write_token, _ = await invoke_allowed(
         kernel,
@@ -112,7 +133,7 @@ async def main() -> None:
         path="src/demo.py",
         justification="Edit source for the approved task",
     )
-    print("ALLOW repo.write.files src/demo.py")
+    record(receipt, "ALLOW repo.write.files src/demo.py")
 
     try:
         kernel.get_token(
@@ -121,7 +142,7 @@ async def main() -> None:
             justification="Change the release workflow",
         )
     except PolicyDenied:
-        print("DENY repo.write.files .github/workflows/release.yml")
+        record(receipt, "DENY repo.write.files .github/workflows/release.yml")
     else:  # pragma: no cover - defensive
         raise AssertionError("workflow mutation unexpectedly received a grant")
 
@@ -132,7 +153,7 @@ async def main() -> None:
             justification="Read environment credentials",
         )
     except PolicyDenied:
-        print("DENY secrets.read .env")
+        record(receipt, "DENY secrets.read .env")
     else:  # pragma: no cover - defensive
         raise AssertionError("secret access unexpectedly received a grant")
 
@@ -143,7 +164,7 @@ async def main() -> None:
         command_class="test",
         justification="Run the local test suite",
     )
-    print("ALLOW shell.run.tests command_class=test")
+    record(receipt, "ALLOW shell.run.tests command_class=test")
 
     task_id = "ISSUE-253"
     try:
@@ -153,7 +174,7 @@ async def main() -> None:
             justification="Publish the completed task for review",
         )
     except PolicyDenied:
-        print("DENY github.create_pr task=ISSUE-253 before approval")
+        record(receipt, "DENY github.create_pr task=ISSUE-253 before approval")
     else:  # pragma: no cover - defensive
         raise AssertionError("PR creation unexpectedly bypassed task approval")
 
@@ -168,7 +189,7 @@ async def main() -> None:
         task_id=task_id,
         justification="Create the explicitly approved PR",
     )
-    print("ALLOW github.create_pr task=ISSUE-253 after task-bound approval")
+    record(receipt, "ALLOW github.create_pr task=ISSUE-253 after task-bound approval")
 
     try:
         await kernel.invoke(
@@ -177,7 +198,10 @@ async def main() -> None:
             args={"path": ".github/workflows/release.yml"},
         )
     except DriverError:
-        print("DENY scope substitution src/demo.py -> .github/workflows/release.yml at execution")
+        record(
+            receipt,
+            "DENY scope substitution src/demo.py -> .github/workflows/release.yml at execution",
+        )
     else:  # pragma: no cover - defensive
         raise AssertionError("signed write scope was not enforced by the driver boundary")
 
@@ -185,8 +209,15 @@ async def main() -> None:
     assert trace.capability_id == "repo.read.files"
     assert trace.principal_id == "coder"
     assert trace.driver_id == "coding-agent"
-    print("TRACE repo.read.files principal=coder driver=coding-agent")
-    print("PASS: useful coding work stays usable while sensitive authority stays explicit.")
+    record(receipt, "TRACE repo.read.files principal=coder driver=coding-agent")
+    record(
+        receipt,
+        "PASS: useful coding work stays usable while sensitive authority stays explicit.",
+    )
+
+    actual = "\n".join(receipt) + "\n"
+    expected = EXPECTED_RECEIPT.read_text(encoding="utf-8")
+    assert actual == expected, "coding-agent flagship receipt drifted from its maintained fixture"
 
 
 if __name__ == "__main__":

--- a/examples/coding_agent_least_privilege.py
+++ b/examples/coding_agent_least_privilege.py
@@ -1,0 +1,193 @@
+"""Deterministic coding-agent least-privilege flagship demo.
+
+Run with::
+
+    python examples/coding_agent_least_privilege.py
+
+The demo uses only the published ``weaver-kernel`` core package. No network,
+real filesystem mutation, GitHub token, or sibling Weaver project is required.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+os.environ.setdefault("WEAVER_KERNEL_SECRET", "coding-agent-demo-not-for-production")
+
+from weaver_kernel import Capability, CapabilityRegistry, InMemoryDriver, Kernel, Principal, SafetyClass, SensitivityTag, StaticRouter
+from weaver_kernel.coding_agent import CodingAgentPolicyEngine, enforce_coding_agent_constraints
+from weaver_kernel.drivers.base import ExecutionContext
+from weaver_kernel.errors import DriverError, PolicyDenied
+from weaver_kernel.models import CapabilityRequest
+
+CAPABILITIES: tuple[tuple[str, SafetyClass, SensitivityTag], ...] = (
+    ("repo.read.files", SafetyClass.READ, SensitivityTag.NONE),
+    ("repo.write.files", SafetyClass.WRITE, SensitivityTag.NONE),
+    ("shell.run.tests", SafetyClass.WRITE, SensitivityTag.NONE),
+    ("shell.run.networked_command", SafetyClass.WRITE, SensitivityTag.NONE),
+    ("secrets.read", SafetyClass.READ, SensitivityTag.SECRETS),
+    ("github.create_pr", SafetyClass.WRITE, SensitivityTag.NONE),
+    ("github.merge_pr", SafetyClass.DESTRUCTIVE, SensitivityTag.NONE),
+)
+
+
+def build_kernel() -> Kernel:
+    """Build a local kernel whose fake driver enforces signed grant scope."""
+    registry = CapabilityRegistry()
+    routes: dict[str, list[str]] = {}
+    driver = InMemoryDriver(driver_id="coding-agent")
+
+    def execute(ctx: ExecutionContext) -> dict[str, object]:
+        enforce_coding_agent_constraints(ctx.constraints, ctx.args)
+        return {"status": "executed", "capability": ctx.capability_id}
+
+    for capability_id, safety_class, sensitivity in CAPABILITIES:
+        registry.register(
+            Capability(
+                capability_id=capability_id,
+                name=capability_id,
+                description=f"Demo capability {capability_id}",
+                safety_class=safety_class,
+                sensitivity=sensitivity,
+            )
+        )
+        routes[capability_id] = ["coding-agent"]
+        driver.register_handler(capability_id, execute)
+
+    kernel = Kernel(
+        registry=registry,
+        policy=CodingAgentPolicyEngine(),
+        router=StaticRouter(routes=routes),
+    )
+    kernel.register_driver(driver)
+    return kernel
+
+
+def request(capability_id: str, **scope: str) -> CapabilityRequest:
+    """Create one host-normalized coding-agent request."""
+    return CapabilityRequest(
+        capability_id=capability_id,
+        goal=f"coding-agent demo: {capability_id}",
+        scope=scope,
+    )
+
+
+async def invoke_allowed(
+    kernel: Kernel,
+    principal: Principal,
+    capability_id: str,
+    *,
+    justification: str,
+    **scope: str,
+):
+    """Grant and invoke one action using the same exact scope arguments."""
+    token = kernel.get_token(
+        request(capability_id, **scope),
+        principal,
+        justification=justification,
+    )
+    frame = await kernel.invoke(token, principal=principal, args=dict(scope))
+    return token, frame
+
+
+async def main() -> None:
+    """Run the maintained ALLOW / DENY / escalation / anti-swap receipt."""
+    kernel = build_kernel()
+    coder = Principal(principal_id="coder")
+
+    _, read_frame = await invoke_allowed(
+        kernel,
+        coder,
+        "repo.read.files",
+        path="README.md",
+        justification="Review the repository README",
+    )
+    print("ALLOW repo.read.files README.md")
+
+    write_token, _ = await invoke_allowed(
+        kernel,
+        coder,
+        "repo.write.files",
+        path="src/demo.py",
+        justification="Edit source for the approved task",
+    )
+    print("ALLOW repo.write.files src/demo.py")
+
+    try:
+        kernel.get_token(
+            request("repo.write.files", path=".github/workflows/release.yml"),
+            coder,
+            justification="Change the release workflow",
+        )
+    except PolicyDenied:
+        print("DENY repo.write.files .github/workflows/release.yml")
+    else:  # pragma: no cover - defensive
+        raise AssertionError("workflow mutation unexpectedly received a grant")
+
+    try:
+        kernel.get_token(
+            request("secrets.read", path=".env"),
+            coder,
+            justification="Read environment credentials",
+        )
+    except PolicyDenied:
+        print("DENY secrets.read .env")
+    else:  # pragma: no cover - defensive
+        raise AssertionError("secret access unexpectedly received a grant")
+
+    await invoke_allowed(
+        kernel,
+        coder,
+        "shell.run.tests",
+        command_class="test",
+        justification="Run the local test suite",
+    )
+    print("ALLOW shell.run.tests command_class=test")
+
+    task_id = "ISSUE-253"
+    try:
+        kernel.get_token(
+            request("github.create_pr", task_id=task_id),
+            coder,
+            justification="Publish the completed task for review",
+        )
+    except PolicyDenied:
+        print("DENY github.create_pr task=ISSUE-253 before approval")
+    else:  # pragma: no cover - defensive
+        raise AssertionError("PR creation unexpectedly bypassed task approval")
+
+    approved_coder = Principal(
+        principal_id="coder",
+        attributes={"approved_task_id": task_id},
+    )
+    await invoke_allowed(
+        kernel,
+        approved_coder,
+        "github.create_pr",
+        task_id=task_id,
+        justification="Create the explicitly approved PR",
+    )
+    print("ALLOW github.create_pr task=ISSUE-253 after task-bound approval")
+
+    try:
+        await kernel.invoke(
+            write_token,
+            principal=coder,
+            args={"path": ".github/workflows/release.yml"},
+        )
+    except DriverError:
+        print("DENY scope substitution src/demo.py -> .github/workflows/release.yml at execution")
+    else:  # pragma: no cover - defensive
+        raise AssertionError("signed write scope was not enforced by the driver boundary")
+
+    trace = kernel.explain(read_frame.action_id)
+    assert trace.capability_id == "repo.read.files"
+    assert trace.principal_id == "coder"
+    assert trace.driver_id == "coding-agent"
+    print("TRACE repo.read.files principal=coder driver=coding-agent")
+    print("PASS: useful coding work stays usable while sensitive authority stays explicit.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/weaver_kernel/coding_agent.py
+++ b/src/weaver_kernel/coding_agent.py
@@ -9,9 +9,8 @@ and then substitute different invocation arguments.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, NoReturn
 
-from .enums import SafetyClass
 from .errors import DriverError, PolicyDenied
 from .models import (
     Capability,
@@ -93,7 +92,7 @@ class CodingAgentPolicyEngine:
             path = self._required_scope(request, "path")
             if scope_globs_match({"path": path}, {"path": list(self.config.secret_path_globs)}):
                 self._deny("Secret-like repository paths require the secrets.read capability.")
-            return self._allow(capability, principal, {"path": path})
+            return self._allow(request, capability, principal, {"path": path})
 
         if cid == "repo.write.files":
             path = self._required_scope(request, "path")
@@ -106,7 +105,7 @@ class CodingAgentPolicyEngine:
                     f"Path {path!r} is outside the configured coding-agent write scope.",
                     reason_code=str(DenialReason.SCOPE_NOT_ALLOWED),
                 )
-            return self._allow(capability, principal, {"path": path})
+            return self._allow(request, capability, principal, {"path": path})
 
         if cid == "shell.run.tests":
             command_class = self._required_scope(request, "command_class")
@@ -115,7 +114,7 @@ class CodingAgentPolicyEngine:
                     f"Command class {command_class!r} is not an allowed test command class.",
                     reason_code=str(DenialReason.SCOPE_NOT_ALLOWED),
                 )
-            return self._allow(capability, principal, {"command_class": command_class})
+            return self._allow(request, capability, principal, {"command_class": command_class})
 
         if cid == "shell.run.networked_command":
             if self.config.network_role not in principal.roles:
@@ -124,7 +123,7 @@ class CodingAgentPolicyEngine:
                     reason_code=str(DenialReason.MISSING_ROLE),
                 )
             command_class = self._required_scope(request, "command_class")
-            return self._allow(capability, principal, {"command_class": command_class})
+            return self._allow(request, capability, principal, {"command_class": command_class})
 
         if cid == "secrets.read":
             if self.config.secrets_role not in principal.roles:
@@ -133,7 +132,7 @@ class CodingAgentPolicyEngine:
                     reason_code=str(DenialReason.MISSING_ROLE),
                 )
             path = self._required_scope(request, "path")
-            return self._allow(capability, principal, {"path": path})
+            return self._allow(request, capability, principal, {"path": path})
 
         if cid == "github.create_pr":
             task_id = self._required_scope(request, "task_id")
@@ -143,7 +142,7 @@ class CodingAgentPolicyEngine:
                     f"PR creation requires an approval bound to task {task_id!r}.",
                     reason_code=str(DenialReason.MISSING_ATTRIBUTE),
                 )
-            return self._allow(capability, principal, {"task_id": task_id})
+            return self._allow(request, capability, principal, {"task_id": task_id})
 
         if cid == "github.merge_pr":
             if self.config.merge_role not in principal.roles:
@@ -152,7 +151,7 @@ class CodingAgentPolicyEngine:
                     reason_code=str(DenialReason.MISSING_ROLE),
                 )
             task_id = self._required_scope(request, "task_id")
-            return self._allow(capability, principal, {"task_id": task_id})
+            return self._allow(request, capability, principal, {"task_id": task_id})
 
         self._deny(
             f"CodingAgentPolicyEngine has no rule for capability {cid!r}.",
@@ -170,7 +169,7 @@ class CodingAgentPolicyEngine:
         return value
 
     @staticmethod
-    def _deny(message: str, *, reason_code: str | None = None) -> None:
+    def _deny(message: str, *, reason_code: str | None = None) -> NoReturn:
         raise PolicyDenied(
             message,
             reason_code=reason_code or str(DenialReason.EXPLICIT_DENY_RULE),
@@ -178,6 +177,7 @@ class CodingAgentPolicyEngine:
 
     @staticmethod
     def _allow(
+        request: CapabilityRequest,
         capability: Capability,
         principal: Principal,
         bound_scope: dict[str, str],
@@ -188,6 +188,8 @@ class CodingAgentPolicyEngine:
             engine="CodingAgentPolicyEngine",
             capability_id=capability.capability_id,
             principal_id=principal.principal_id,
+            intent=request.intent,
+            scope_keys=sorted(request.scope),
         )
         trace.steps.append(
             PolicyTraceStep(

--- a/src/weaver_kernel/coding_agent.py
+++ b/src/weaver_kernel/coding_agent.py
@@ -28,14 +28,16 @@ from .policy_reasons import AllowReason, DenialReason
 class CodingAgentPolicyConfig:
     """Configuration for :class:`CodingAgentPolicyEngine`.
 
-    The defaults intentionally permit ordinary repository work while keeping
-    secrets, workflow mutation, networked commands, PR creation, and merges
-    behind narrower grants.
+    Defaults allow ordinary source/test/docs work only to principals carrying
+    explicit work roles, while secrets, workflow mutation, networked commands,
+    PR creation, and merges remain behind narrower grants.
     """
 
     writable_path_globs: tuple[str, ...] = ("src/**", "tests/**", "docs/**")
     secret_path_globs: tuple[str, ...] = (".env", "**/.env", "**/secrets/**")
     test_command_classes: tuple[str, ...] = ("test",)
+    write_role: str = "code_writer"
+    test_role: str = "test_runner"
     network_role: str = "network_runner"
     secrets_role: str = "secrets_reader"
     merge_role: str = "admin"
@@ -95,6 +97,7 @@ class CodingAgentPolicyEngine:
             return self._allow(request, capability, principal, {"path": path})
 
         if cid == "repo.write.files":
+            self._require_role(principal, self.config.write_role, "Repository writes")
             path = self._required_scope(request, "path")
             if scope_globs_match({"path": path}, {"path": list(self.config.secret_path_globs)}):
                 self._deny("Secret-like paths are never writable through repo.write.files.")
@@ -108,6 +111,7 @@ class CodingAgentPolicyEngine:
             return self._allow(request, capability, principal, {"path": path})
 
         if cid == "shell.run.tests":
+            self._require_role(principal, self.config.test_role, "Test execution")
             command_class = self._required_scope(request, "command_class")
             if command_class not in self.config.test_command_classes:
                 self._deny(
@@ -117,20 +121,12 @@ class CodingAgentPolicyEngine:
             return self._allow(request, capability, principal, {"command_class": command_class})
 
         if cid == "shell.run.networked_command":
-            if self.config.network_role not in principal.roles:
-                self._deny(
-                    f"Networked shell commands require role {self.config.network_role!r}.",
-                    reason_code=str(DenialReason.MISSING_ROLE),
-                )
+            self._require_role(principal, self.config.network_role, "Networked shell commands")
             command_class = self._required_scope(request, "command_class")
             return self._allow(request, capability, principal, {"command_class": command_class})
 
         if cid == "secrets.read":
-            if self.config.secrets_role not in principal.roles:
-                self._deny(
-                    f"Secret access requires role {self.config.secrets_role!r}.",
-                    reason_code=str(DenialReason.MISSING_ROLE),
-                )
+            self._require_role(principal, self.config.secrets_role, "Secret access")
             path = self._required_scope(request, "path")
             return self._allow(request, capability, principal, {"path": path})
 
@@ -145,11 +141,7 @@ class CodingAgentPolicyEngine:
             return self._allow(request, capability, principal, {"task_id": task_id})
 
         if cid == "github.merge_pr":
-            if self.config.merge_role not in principal.roles:
-                self._deny(
-                    f"PR merge requires role {self.config.merge_role!r}.",
-                    reason_code=str(DenialReason.MISSING_ROLE),
-                )
+            self._require_role(principal, self.config.merge_role, "PR merge")
             task_id = self._required_scope(request, "task_id")
             return self._allow(request, capability, principal, {"task_id": task_id})
 
@@ -167,6 +159,14 @@ class CodingAgentPolicyEngine:
                 reason_code=str(DenialReason.SCOPE_NOT_ALLOWED),
             )
         return value
+
+    @classmethod
+    def _require_role(cls, principal: Principal, role: str, action: str) -> None:
+        if role not in principal.roles:
+            cls._deny(
+                f"{action} require role {role!r}.",
+                reason_code=str(DenialReason.MISSING_ROLE),
+            )
 
     @staticmethod
     def _deny(message: str, *, reason_code: str | None = None) -> NoReturn:

--- a/src/weaver_kernel/coding_agent.py
+++ b/src/weaver_kernel/coding_agent.py
@@ -1,0 +1,238 @@
+"""Least-privilege policy helpers for coding-agent runtimes.
+
+The policy binds the concrete scope approved at grant time into the signed
+capability token. Drivers call :func:`enforce_coding_agent_constraints` before
+performing the side effect so an agent cannot obtain a grant for one path/task
+and then substitute different invocation arguments.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from .enums import SafetyClass
+from .errors import DriverError, PolicyDenied
+from .models import (
+    Capability,
+    CapabilityRequest,
+    PolicyDecision,
+    PolicyDecisionTrace,
+    PolicyTraceStep,
+    Principal,
+)
+from .policy_matching import scope_globs_match
+from .policy_reasons import AllowReason, DenialReason
+
+
+@dataclass(frozen=True, slots=True)
+class CodingAgentPolicyConfig:
+    """Configuration for :class:`CodingAgentPolicyEngine`.
+
+    The defaults intentionally permit ordinary repository work while keeping
+    secrets, workflow mutation, networked commands, PR creation, and merges
+    behind narrower grants.
+    """
+
+    writable_path_globs: tuple[str, ...] = ("src/**", "tests/**", "docs/**")
+    secret_path_globs: tuple[str, ...] = (".env", "**/.env", "**/secrets/**")
+    test_command_classes: tuple[str, ...] = ("test",)
+    network_role: str = "network_runner"
+    secrets_role: str = "secrets_reader"
+    merge_role: str = "admin"
+    pr_approval_attribute: str = "approved_task_id"
+
+
+class CodingAgentPolicyEngine:
+    """Policy engine for a minimal coding-agent capability vocabulary.
+
+    Supported capability IDs are ``repo.read.files``, ``repo.write.files``,
+    ``shell.run.tests``, ``shell.run.networked_command``, ``secrets.read``,
+    ``github.create_pr``, and ``github.merge_pr``. Unknown capabilities fail
+    closed.
+    """
+
+    def __init__(self, config: CodingAgentPolicyConfig | None = None) -> None:
+        """Initialize the policy.
+
+        Args:
+            config: Optional policy configuration. Defaults to conservative
+                local-development scopes.
+        """
+        self.config = config or CodingAgentPolicyConfig()
+
+    def evaluate(
+        self,
+        request: CapabilityRequest,
+        capability: Capability,
+        principal: Principal,
+        *,
+        justification: str,
+    ) -> PolicyDecision:
+        """Evaluate a coding-agent capability request and bind its exact scope.
+
+        Args:
+            request: Capability request with trusted host-supplied scope.
+            capability: Registered capability.
+            principal: Requesting principal.
+            justification: Human-readable justification for audit.
+
+        Returns:
+            An allowed decision whose ``coding_agent`` constraint contains the
+            exact grant-time scope that execution must re-check.
+
+        Raises:
+            PolicyDenied: If the requested action exceeds configured authority.
+        """
+        del justification  # scope/roles are authoritative; prose is audit context only.
+        cid = capability.capability_id
+        if cid != request.capability_id:
+            self._deny("Capability request does not match the registered capability.")
+
+        if cid == "repo.read.files":
+            path = self._required_scope(request, "path")
+            if scope_globs_match({"path": path}, {"path": list(self.config.secret_path_globs)}):
+                self._deny("Secret-like repository paths require the secrets.read capability.")
+            return self._allow(capability, principal, {"path": path})
+
+        if cid == "repo.write.files":
+            path = self._required_scope(request, "path")
+            if scope_globs_match({"path": path}, {"path": list(self.config.secret_path_globs)}):
+                self._deny("Secret-like paths are never writable through repo.write.files.")
+            if not scope_globs_match(
+                {"path": path}, {"path": list(self.config.writable_path_globs)}
+            ):
+                self._deny(
+                    f"Path {path!r} is outside the configured coding-agent write scope.",
+                    reason_code=str(DenialReason.SCOPE_NOT_ALLOWED),
+                )
+            return self._allow(capability, principal, {"path": path})
+
+        if cid == "shell.run.tests":
+            command_class = self._required_scope(request, "command_class")
+            if command_class not in self.config.test_command_classes:
+                self._deny(
+                    f"Command class {command_class!r} is not an allowed test command class.",
+                    reason_code=str(DenialReason.SCOPE_NOT_ALLOWED),
+                )
+            return self._allow(capability, principal, {"command_class": command_class})
+
+        if cid == "shell.run.networked_command":
+            if self.config.network_role not in principal.roles:
+                self._deny(
+                    f"Networked shell commands require role {self.config.network_role!r}.",
+                    reason_code=str(DenialReason.MISSING_ROLE),
+                )
+            command_class = self._required_scope(request, "command_class")
+            return self._allow(capability, principal, {"command_class": command_class})
+
+        if cid == "secrets.read":
+            if self.config.secrets_role not in principal.roles:
+                self._deny(
+                    f"Secret access requires role {self.config.secrets_role!r}.",
+                    reason_code=str(DenialReason.MISSING_ROLE),
+                )
+            path = self._required_scope(request, "path")
+            return self._allow(capability, principal, {"path": path})
+
+        if cid == "github.create_pr":
+            task_id = self._required_scope(request, "task_id")
+            approved = principal.attributes.get(self.config.pr_approval_attribute)
+            if approved != task_id:
+                self._deny(
+                    f"PR creation requires an approval bound to task {task_id!r}.",
+                    reason_code=str(DenialReason.MISSING_ATTRIBUTE),
+                )
+            return self._allow(capability, principal, {"task_id": task_id})
+
+        if cid == "github.merge_pr":
+            if self.config.merge_role not in principal.roles:
+                self._deny(
+                    f"PR merge requires role {self.config.merge_role!r}.",
+                    reason_code=str(DenialReason.MISSING_ROLE),
+                )
+            task_id = self._required_scope(request, "task_id")
+            return self._allow(capability, principal, {"task_id": task_id})
+
+        self._deny(
+            f"CodingAgentPolicyEngine has no rule for capability {cid!r}.",
+            reason_code=str(DenialReason.NO_MATCHING_RULE),
+        )
+
+    @staticmethod
+    def _required_scope(request: CapabilityRequest, key: str) -> str:
+        value = request.scope.get(key)
+        if not isinstance(value, str) or not value:
+            raise PolicyDenied(
+                f"Coding-agent capability {request.capability_id!r} requires non-empty scope {key!r}.",
+                reason_code=str(DenialReason.SCOPE_NOT_ALLOWED),
+            )
+        return value
+
+    @staticmethod
+    def _deny(message: str, *, reason_code: str | None = None) -> None:
+        raise PolicyDenied(
+            message,
+            reason_code=reason_code or str(DenialReason.EXPLICIT_DENY_RULE),
+        )
+
+    @staticmethod
+    def _allow(
+        capability: Capability,
+        principal: Principal,
+        bound_scope: dict[str, str],
+    ) -> PolicyDecision:
+        reason = f"Coding-agent scope approved for {capability.capability_id}."
+        code = str(AllowReason.RULE_ALLOW)
+        trace = PolicyDecisionTrace(
+            engine="CodingAgentPolicyEngine",
+            capability_id=capability.capability_id,
+            principal_id=principal.principal_id,
+        )
+        trace.steps.append(
+            PolicyTraceStep(
+                name="coding-agent-scope",
+                outcome="allowed",
+                detail=f"bound scope keys={sorted(bound_scope)}",
+                reason_code=code,
+            )
+        )
+        trace.final_outcome = "allowed"
+        trace.final_reason_code = code
+        return PolicyDecision(
+            allowed=True,
+            reason=reason,
+            constraints={"coding_agent": dict(bound_scope)},
+            reason_code=code,
+            trace=trace,
+        )
+
+
+def enforce_coding_agent_constraints(constraints: dict[str, Any], args: dict[str, Any]) -> None:
+    """Fail closed if invocation arguments differ from signed coding-agent scope.
+
+    Args:
+        constraints: Verified token constraints passed through
+            :class:`~weaver_kernel.drivers.base.ExecutionContext`.
+        args: Actual driver invocation arguments.
+
+    Raises:
+        DriverError: If a bound scope key is missing or changed at invocation.
+    """
+    bound = constraints.get("coding_agent")
+    if not isinstance(bound, dict) or not bound:
+        raise DriverError("Missing signed coding-agent scope constraints.")
+    for key, expected in bound.items():
+        actual = args.get(key)
+        if actual != expected:
+            raise DriverError(
+                f"Invocation changed signed coding-agent scope {key!r}: "
+                f"expected {expected!r}, got {actual!r}."
+            )
+
+
+__all__ = [
+    "CodingAgentPolicyConfig",
+    "CodingAgentPolicyEngine",
+    "enforce_coding_agent_constraints",
+]

--- a/src/weaver_kernel/coding_agent.py
+++ b/src/weaver_kernel/coding_agent.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, NoReturn
 
+from .enums import SafetyClass
 from .errors import DriverError, PolicyDenied
 from .models import (
     Capability,
@@ -20,6 +21,7 @@ from .models import (
     PolicyTraceStep,
     Principal,
 )
+from .policy import _MIN_JUSTIFICATION
 from .policy_matching import scope_globs_match
 from .policy_reasons import AllowReason, DenialReason
 
@@ -34,7 +36,12 @@ class CodingAgentPolicyConfig:
     """
 
     writable_path_globs: tuple[str, ...] = ("src/**", "tests/**", "docs/**")
-    secret_path_globs: tuple[str, ...] = (".env", "**/.env", "**/secrets/**")
+    secret_path_globs: tuple[str, ...] = (
+        ".env",
+        "**/.env",
+        "secrets/**",
+        "**/secrets/**",
+    )
     test_command_classes: tuple[str, ...] = ("test",)
     write_role: str = "code_writer"
     test_role: str = "test_runner"
@@ -76,7 +83,9 @@ class CodingAgentPolicyEngine:
             request: Capability request with trusted host-supplied scope.
             capability: Registered capability.
             principal: Requesting principal.
-            justification: Human-readable justification for audit.
+            justification: Human-readable justification for audit. WRITE and
+                DESTRUCTIVE grants preserve the repository-wide minimum length
+                invariant after trimming whitespace.
 
         Returns:
             An allowed decision whose ``coding_agent`` constraint contains the
@@ -85,7 +94,6 @@ class CodingAgentPolicyEngine:
         Raises:
             PolicyDenied: If the requested action exceeds configured authority.
         """
-        del justification  # scope/roles are authoritative; prose is audit context only.
         cid = capability.capability_id
         if cid != request.capability_id:
             self._deny("Capability request does not match the registered capability.")
@@ -97,7 +105,7 @@ class CodingAgentPolicyEngine:
             return self._allow(request, capability, principal, {"path": path})
 
         if cid == "repo.write.files":
-            self._require_role(principal, self.config.write_role, "Repository writes")
+            self._require_role(principal, self.config.write_role, "repository writes")
             path = self._required_scope(request, "path")
             if scope_globs_match({"path": path}, {"path": list(self.config.secret_path_globs)}):
                 self._deny("Secret-like paths are never writable through repo.write.files.")
@@ -108,25 +116,28 @@ class CodingAgentPolicyEngine:
                     f"Path {path!r} is outside the configured coding-agent write scope.",
                     reason_code=str(DenialReason.SCOPE_NOT_ALLOWED),
                 )
+            self._require_justification(capability, justification)
             return self._allow(request, capability, principal, {"path": path})
 
         if cid == "shell.run.tests":
-            self._require_role(principal, self.config.test_role, "Test execution")
+            self._require_role(principal, self.config.test_role, "test execution")
             command_class = self._required_scope(request, "command_class")
             if command_class not in self.config.test_command_classes:
                 self._deny(
                     f"Command class {command_class!r} is not an allowed test command class.",
                     reason_code=str(DenialReason.SCOPE_NOT_ALLOWED),
                 )
+            self._require_justification(capability, justification)
             return self._allow(request, capability, principal, {"command_class": command_class})
 
         if cid == "shell.run.networked_command":
-            self._require_role(principal, self.config.network_role, "Networked shell commands")
+            self._require_role(principal, self.config.network_role, "networked shell commands")
             command_class = self._required_scope(request, "command_class")
+            self._require_justification(capability, justification)
             return self._allow(request, capability, principal, {"command_class": command_class})
 
         if cid == "secrets.read":
-            self._require_role(principal, self.config.secrets_role, "Secret access")
+            self._require_role(principal, self.config.secrets_role, "secret access")
             path = self._required_scope(request, "path")
             return self._allow(request, capability, principal, {"path": path})
 
@@ -138,11 +149,13 @@ class CodingAgentPolicyEngine:
                     f"PR creation requires an approval bound to task {task_id!r}.",
                     reason_code=str(DenialReason.MISSING_ATTRIBUTE),
                 )
+            self._require_justification(capability, justification)
             return self._allow(request, capability, principal, {"task_id": task_id})
 
         if cid == "github.merge_pr":
             self._require_role(principal, self.config.merge_role, "PR merge")
             task_id = self._required_scope(request, "task_id")
+            self._require_justification(capability, justification)
             return self._allow(request, capability, principal, {"task_id": task_id})
 
         self._deny(
@@ -164,8 +177,20 @@ class CodingAgentPolicyEngine:
     def _require_role(cls, principal: Principal, role: str, action: str) -> None:
         if role not in principal.roles:
             cls._deny(
-                f"{action} require role {role!r}.",
+                f"Required role {role!r} is missing for {action}.",
                 reason_code=str(DenialReason.MISSING_ROLE),
+            )
+
+    @classmethod
+    def _require_justification(cls, capability: Capability, justification: str) -> None:
+        if capability.safety_class not in (SafetyClass.WRITE, SafetyClass.DESTRUCTIVE):
+            return
+        stripped_len = len(justification.strip())
+        if stripped_len < _MIN_JUSTIFICATION:
+            cls._deny(
+                f"{capability.safety_class.value.upper()} capabilities require a justification "
+                f"of at least {_MIN_JUSTIFICATION} characters after trimming whitespace.",
+                reason_code=str(DenialReason.INSUFFICIENT_JUSTIFICATION),
             )
 
     @staticmethod

--- a/src/weaver_kernel/policy_matching.py
+++ b/src/weaver_kernel/policy_matching.py
@@ -1,0 +1,44 @@
+"""Shared deterministic match helpers for declarative policy rules."""
+
+from __future__ import annotations
+
+from fnmatch import fnmatchcase
+from typing import Any
+
+
+def scope_globs_match(scope: dict[str, Any], required: dict[str, list[str]] | None) -> bool:
+    """Return whether string scope values match every configured glob set.
+
+    Args:
+        scope: Trusted, host-supplied request scope values.
+        required: Mapping of scope key to one-or-more shell-style glob patterns.
+
+    Returns:
+        ``True`` when every required key is present as a string and matches at
+        least one pattern for that key. ``None`` means no glob condition.
+    """
+    if required is None:
+        return True
+    for key, patterns in required.items():
+        value = scope.get(key)
+        if not isinstance(value, str) or not any(fnmatchcase(value, pattern) for pattern in patterns):
+            return False
+    return True
+
+
+def matching_scope_glob_patterns(value: Any, patterns: list[str]) -> list[str]:
+    """Return configured patterns matching one trusted scope value.
+
+    Args:
+        value: Scope value to inspect.
+        patterns: Candidate shell-style glob patterns.
+
+    Returns:
+        Matching patterns in configuration order; non-string values match none.
+    """
+    if not isinstance(value, str):
+        return []
+    return [pattern for pattern in patterns if fnmatchcase(value, pattern)]
+
+
+__all__ = ["matching_scope_glob_patterns", "scope_globs_match"]

--- a/src/weaver_kernel/policy_matching.py
+++ b/src/weaver_kernel/policy_matching.py
@@ -21,7 +21,9 @@ def scope_globs_match(scope: dict[str, Any], required: dict[str, list[str]] | No
         return True
     for key, patterns in required.items():
         value = scope.get(key)
-        if not isinstance(value, str) or not any(fnmatchcase(value, pattern) for pattern in patterns):
+        if not isinstance(value, str) or not any(
+            fnmatchcase(value, pattern) for pattern in patterns
+        ):
             return False
     return True
 

--- a/tests/test_coding_agent.py
+++ b/tests/test_coding_agent.py
@@ -4,14 +4,21 @@ from __future__ import annotations
 
 import pytest
 
-from weaver_kernel.coding_agent import CodingAgentPolicyEngine, enforce_coding_agent_constraints
+from weaver_kernel.coding_agent import (
+    CodingAgentPolicyEngine,
+    enforce_coding_agent_constraints,
+)
 from weaver_kernel.enums import SafetyClass, SensitivityTag
 from weaver_kernel.errors import DriverError, PolicyDenied
 from weaver_kernel.models import Capability, CapabilityRequest, Principal
 from weaver_kernel.policy_reasons import DenialReason
 
 
-def _cap(capability_id: str, safety: SafetyClass, sensitivity: SensitivityTag = SensitivityTag.NONE) -> Capability:
+def _cap(
+    capability_id: str,
+    safety: SafetyClass,
+    sensitivity: SensitivityTag = SensitivityTag.NONE,
+) -> Capability:
     return Capability(
         capability_id=capability_id,
         name=capability_id,
@@ -31,23 +38,41 @@ def test_repo_read_allows_normal_path_but_not_secret_path() -> None:
     cap = _cap("repo.read.files", SafetyClass.READ)
 
     decision = engine.evaluate(
-        _request("repo.read.files", path="README.md"), cap, principal, justification="inspect repo"
+        _request("repo.read.files", path="README.md"),
+        cap,
+        principal,
+        justification="inspect repo",
     )
     assert decision.constraints == {"coding_agent": {"path": "README.md"}}
 
     with pytest.raises(PolicyDenied, match="Secret-like"):
         engine.evaluate(
-            _request("repo.read.files", path=".env"), cap, principal, justification="inspect repo"
+            _request("repo.read.files", path=".env"),
+            cap,
+            principal,
+            justification="inspect repo",
         )
 
 
-def test_repo_write_is_path_scoped() -> None:
+def test_repo_write_requires_role_and_is_path_scoped() -> None:
     engine = CodingAgentPolicyEngine()
-    principal = Principal(principal_id="coder")
     cap = _cap("repo.write.files", SafetyClass.WRITE)
 
+    with pytest.raises(PolicyDenied) as role_exc:
+        engine.evaluate(
+            _request("repo.write.files", path="src/app.py"),
+            cap,
+            Principal(principal_id="reviewer"),
+            justification="edit source",
+        )
+    assert role_exc.value.reason_code == DenialReason.MISSING_ROLE
+
+    principal = Principal(principal_id="coder", roles=["code_writer"])
     decision = engine.evaluate(
-        _request("repo.write.files", path="src/app.py"), cap, principal, justification="edit source"
+        _request("repo.write.files", path="src/app.py"),
+        cap,
+        principal,
+        justification="edit source",
     )
     assert decision.constraints["coding_agent"]["path"] == "src/app.py"
 
@@ -63,7 +88,7 @@ def test_repo_write_is_path_scoped() -> None:
 
 def test_test_commands_are_separate_from_networked_commands() -> None:
     engine = CodingAgentPolicyEngine()
-    principal = Principal(principal_id="coder")
+    principal = Principal(principal_id="coder", roles=["test_runner"])
 
     test_cap = _cap("shell.run.tests", SafetyClass.WRITE)
     decision = engine.evaluate(

--- a/tests/test_coding_agent.py
+++ b/tests/test_coding_agent.py
@@ -1,0 +1,146 @@
+"""Tests for the coding-agent least-privilege policy surface."""
+
+from __future__ import annotations
+
+import pytest
+
+from weaver_kernel.coding_agent import CodingAgentPolicyEngine, enforce_coding_agent_constraints
+from weaver_kernel.enums import SafetyClass, SensitivityTag
+from weaver_kernel.errors import DriverError, PolicyDenied
+from weaver_kernel.models import Capability, CapabilityRequest, Principal
+from weaver_kernel.policy_reasons import DenialReason
+
+
+def _cap(capability_id: str, safety: SafetyClass, sensitivity: SensitivityTag = SensitivityTag.NONE) -> Capability:
+    return Capability(
+        capability_id=capability_id,
+        name=capability_id,
+        description="test coding-agent capability",
+        safety_class=safety,
+        sensitivity=sensitivity,
+    )
+
+
+def _request(capability_id: str, **scope: str) -> CapabilityRequest:
+    return CapabilityRequest(capability_id=capability_id, goal="test", scope=scope)
+
+
+def test_repo_read_allows_normal_path_but_not_secret_path() -> None:
+    engine = CodingAgentPolicyEngine()
+    principal = Principal(principal_id="coder")
+    cap = _cap("repo.read.files", SafetyClass.READ)
+
+    decision = engine.evaluate(
+        _request("repo.read.files", path="README.md"), cap, principal, justification="inspect repo"
+    )
+    assert decision.constraints == {"coding_agent": {"path": "README.md"}}
+
+    with pytest.raises(PolicyDenied, match="Secret-like"):
+        engine.evaluate(
+            _request("repo.read.files", path=".env"), cap, principal, justification="inspect repo"
+        )
+
+
+def test_repo_write_is_path_scoped() -> None:
+    engine = CodingAgentPolicyEngine()
+    principal = Principal(principal_id="coder")
+    cap = _cap("repo.write.files", SafetyClass.WRITE)
+
+    decision = engine.evaluate(
+        _request("repo.write.files", path="src/app.py"), cap, principal, justification="edit source"
+    )
+    assert decision.constraints["coding_agent"]["path"] == "src/app.py"
+
+    with pytest.raises(PolicyDenied) as exc:
+        engine.evaluate(
+            _request("repo.write.files", path=".github/workflows/release.yml"),
+            cap,
+            principal,
+            justification="edit workflow",
+        )
+    assert exc.value.reason_code == DenialReason.SCOPE_NOT_ALLOWED
+
+
+def test_test_commands_are_separate_from_networked_commands() -> None:
+    engine = CodingAgentPolicyEngine()
+    principal = Principal(principal_id="coder")
+
+    test_cap = _cap("shell.run.tests", SafetyClass.WRITE)
+    decision = engine.evaluate(
+        _request("shell.run.tests", command_class="test"),
+        test_cap,
+        principal,
+        justification="run tests",
+    )
+    assert decision.constraints["coding_agent"]["command_class"] == "test"
+
+    network_cap = _cap("shell.run.networked_command", SafetyClass.WRITE)
+    with pytest.raises(PolicyDenied) as exc:
+        engine.evaluate(
+            _request("shell.run.networked_command", command_class="package-install"),
+            network_cap,
+            principal,
+            justification="install dependency",
+        )
+    assert exc.value.reason_code == DenialReason.MISSING_ROLE
+
+
+def test_pr_creation_requires_task_bound_approval_and_merge_is_separate() -> None:
+    engine = CodingAgentPolicyEngine()
+    principal = Principal(principal_id="coder")
+    create_cap = _cap("github.create_pr", SafetyClass.WRITE)
+    request = _request("github.create_pr", task_id="ISSUE-253")
+
+    with pytest.raises(PolicyDenied) as exc:
+        engine.evaluate(request, create_cap, principal, justification="open PR")
+    assert exc.value.reason_code == DenialReason.MISSING_ATTRIBUTE
+
+    approved = Principal(
+        principal_id="coder",
+        attributes={"approved_task_id": "ISSUE-253"},
+    )
+    decision = engine.evaluate(request, create_cap, approved, justification="open approved PR")
+    assert decision.constraints["coding_agent"]["task_id"] == "ISSUE-253"
+
+    merge_cap = _cap("github.merge_pr", SafetyClass.DESTRUCTIVE)
+    with pytest.raises(PolicyDenied) as merge_exc:
+        engine.evaluate(
+            _request("github.merge_pr", task_id="ISSUE-253"),
+            merge_cap,
+            approved,
+            justification="merge PR",
+        )
+    assert merge_exc.value.reason_code == DenialReason.MISSING_ROLE
+
+
+def test_secret_read_requires_explicit_secrets_role() -> None:
+    engine = CodingAgentPolicyEngine()
+    cap = _cap("secrets.read", SafetyClass.READ, SensitivityTag.SECRETS)
+    request = _request("secrets.read", path=".env")
+
+    with pytest.raises(PolicyDenied):
+        engine.evaluate(request, cap, Principal(principal_id="coder"), justification="read env")
+
+    decision = engine.evaluate(
+        request,
+        cap,
+        Principal(principal_id="coder", roles=["secrets_reader"]),
+        justification="approved secret lookup",
+    )
+    assert decision.allowed is True
+
+
+def test_execution_helper_blocks_scope_substitution_after_grant() -> None:
+    constraints = {"coding_agent": {"path": "src/app.py"}}
+    enforce_coding_agent_constraints(constraints, {"path": "src/app.py"})
+
+    with pytest.raises(DriverError, match="changed signed coding-agent scope"):
+        enforce_coding_agent_constraints(
+            constraints,
+            {"path": ".github/workflows/release.yml"},
+        )
+
+
+def test_execution_helper_fails_closed_without_signed_scope() -> None:
+    with pytest.raises(DriverError, match="Missing signed coding-agent scope"):
+        enforce_coding_agent_constraints({}, {"path": "src/app.py"})

--- a/tests/test_coding_agent.py
+++ b/tests/test_coding_agent.py
@@ -45,25 +45,26 @@ def test_repo_read_allows_normal_path_but_not_secret_path() -> None:
     )
     assert decision.constraints == {"coding_agent": {"path": "README.md"}}
 
-    with pytest.raises(PolicyDenied, match="Secret-like"):
-        engine.evaluate(
-            _request("repo.read.files", path=".env"),
-            cap,
-            principal,
-            justification="inspect repo",
-        )
+    for secret_path in (".env", "secrets/api-token.txt"):
+        with pytest.raises(PolicyDenied, match="Secret-like repository paths"):
+            engine.evaluate(
+                _request("repo.read.files", path=secret_path),
+                cap,
+                principal,
+                justification="inspect repo",
+            )
 
 
 def test_repo_write_requires_role_and_is_path_scoped() -> None:
     engine = CodingAgentPolicyEngine()
     cap = _cap("repo.write.files", SafetyClass.WRITE)
 
-    with pytest.raises(PolicyDenied) as role_exc:
+    with pytest.raises(PolicyDenied, match="Required role 'code_writer' is missing") as role_exc:
         engine.evaluate(
             _request("repo.write.files", path="src/app.py"),
             cap,
             Principal(principal_id="reviewer"),
-            justification="edit source",
+            justification="edit source for task",
         )
     assert role_exc.value.reason_code == DenialReason.MISSING_ROLE
 
@@ -72,18 +73,39 @@ def test_repo_write_requires_role_and_is_path_scoped() -> None:
         _request("repo.write.files", path="src/app.py"),
         cap,
         principal,
-        justification="edit source",
+        justification="edit source for approved task",
     )
     assert decision.constraints["coding_agent"]["path"] == "src/app.py"
 
-    with pytest.raises(PolicyDenied) as exc:
+    with pytest.raises(
+        PolicyDenied,
+        match="outside the configured coding-agent write scope",
+    ) as exc:
         engine.evaluate(
             _request("repo.write.files", path=".github/workflows/release.yml"),
             cap,
             principal,
-            justification="edit workflow",
+            justification="edit workflow for approved task",
         )
     assert exc.value.reason_code == DenialReason.SCOPE_NOT_ALLOWED
+
+
+def test_write_grant_rejects_whitespace_only_justification() -> None:
+    engine = CodingAgentPolicyEngine()
+    principal = Principal(principal_id="coder", roles=["code_writer"])
+    cap = _cap("repo.write.files", SafetyClass.WRITE)
+
+    with pytest.raises(
+        PolicyDenied,
+        match="WRITE capabilities require a justification of at least 15 characters",
+    ) as exc:
+        engine.evaluate(
+            _request("repo.write.files", path="src/app.py"),
+            cap,
+            principal,
+            justification="                    ",
+        )
+    assert exc.value.reason_code == DenialReason.INSUFFICIENT_JUSTIFICATION
 
 
 def test_test_commands_are_separate_from_networked_commands() -> None:
@@ -95,17 +117,17 @@ def test_test_commands_are_separate_from_networked_commands() -> None:
         _request("shell.run.tests", command_class="test"),
         test_cap,
         principal,
-        justification="run tests",
+        justification="run the local test suite",
     )
     assert decision.constraints["coding_agent"]["command_class"] == "test"
 
     network_cap = _cap("shell.run.networked_command", SafetyClass.WRITE)
-    with pytest.raises(PolicyDenied) as exc:
+    with pytest.raises(PolicyDenied, match="Required role 'network_runner' is missing") as exc:
         engine.evaluate(
             _request("shell.run.networked_command", command_class="package-install"),
             network_cap,
             principal,
-            justification="install dependency",
+            justification="install approved dependency",
         )
     assert exc.value.reason_code == DenialReason.MISSING_ROLE
 
@@ -116,24 +138,34 @@ def test_pr_creation_requires_task_bound_approval_and_merge_is_separate() -> Non
     create_cap = _cap("github.create_pr", SafetyClass.WRITE)
     request = _request("github.create_pr", task_id="ISSUE-253")
 
-    with pytest.raises(PolicyDenied) as exc:
-        engine.evaluate(request, create_cap, principal, justification="open PR")
+    with pytest.raises(PolicyDenied, match="requires an approval bound to task") as exc:
+        engine.evaluate(
+            request,
+            create_cap,
+            principal,
+            justification="open pull request for task",
+        )
     assert exc.value.reason_code == DenialReason.MISSING_ATTRIBUTE
 
     approved = Principal(
         principal_id="coder",
         attributes={"approved_task_id": "ISSUE-253"},
     )
-    decision = engine.evaluate(request, create_cap, approved, justification="open approved PR")
+    decision = engine.evaluate(
+        request,
+        create_cap,
+        approved,
+        justification="open approved pull request",
+    )
     assert decision.constraints["coding_agent"]["task_id"] == "ISSUE-253"
 
     merge_cap = _cap("github.merge_pr", SafetyClass.DESTRUCTIVE)
-    with pytest.raises(PolicyDenied) as merge_exc:
+    with pytest.raises(PolicyDenied, match="Required role 'admin' is missing") as merge_exc:
         engine.evaluate(
             _request("github.merge_pr", task_id="ISSUE-253"),
             merge_cap,
             approved,
-            justification="merge PR",
+            justification="merge approved pull request",
         )
     assert merge_exc.value.reason_code == DenialReason.MISSING_ROLE
 
@@ -143,8 +175,13 @@ def test_secret_read_requires_explicit_secrets_role() -> None:
     cap = _cap("secrets.read", SafetyClass.READ, SensitivityTag.SECRETS)
     request = _request("secrets.read", path=".env")
 
-    with pytest.raises(PolicyDenied):
-        engine.evaluate(request, cap, Principal(principal_id="coder"), justification="read env")
+    with pytest.raises(PolicyDenied, match="Required role 'secrets_reader' is missing"):
+        engine.evaluate(
+            request,
+            cap,
+            Principal(principal_id="coder"),
+            justification="read environment credentials",
+        )
 
     decision = engine.evaluate(
         request,

--- a/tests/test_policy_matching.py
+++ b/tests/test_policy_matching.py
@@ -1,0 +1,27 @@
+"""Tests for shared declarative/coding-agent match helpers."""
+
+from weaver_kernel.policy_matching import matching_scope_glob_patterns, scope_globs_match
+
+
+def test_scope_globs_require_every_key_and_match_one_pattern() -> None:
+    assert scope_globs_match(
+        {"path": "src/app/main.py", "command_class": "test"},
+        {"path": ["src/**", "tests/**"], "command_class": ["test"]},
+    )
+    assert not scope_globs_match(
+        {"path": ".github/workflows/release.yml", "command_class": "test"},
+        {"path": ["src/**", "tests/**"], "command_class": ["test"]},
+    )
+
+
+def test_scope_globs_fail_closed_for_missing_or_non_string_values() -> None:
+    assert not scope_globs_match({}, {"path": ["src/**"]})
+    assert not scope_globs_match({"path": 42}, {"path": ["src/**"]})
+
+
+def test_matching_scope_glob_patterns_preserves_configuration_order() -> None:
+    assert matching_scope_glob_patterns("src/app.py", ["**/*.py", "src/**", "tests/**"]) == [
+        "**/*.py",
+        "src/**",
+    ]
+    assert matching_scope_glob_patterns(None, ["**"]) == []


### PR DESCRIPTION
Advances #253 with a real embedded least-privilege boundary and maintained flagship demo.

## What this adds

- `CodingAgentPolicyEngine` with a deliberately small capability vocabulary for repository reads/writes, test commands, networked shell commands, secrets, PR creation, and PR merge.
- explicit roles for code writes/tests/network/secrets/merge plus task-bound PR approval.
- path-scoped repository writes using deterministic glob matching.
- **signed scope binding**: the exact path/command-class/task approved at grant time is written into token constraints.
- `enforce_coding_agent_constraints()` for drivers to fail closed if invocation arguments are swapped after a valid grant.

That last point is the core security property: a token approved for `src/demo.py` cannot later be reused to mutate `.github/workflows/release.yml`.

## Flagship proof

`python examples/coding_agent_least_privilege.py` is hermetic and makes no real repo/GitHub/network side effects. It demonstrates:

- ALLOW normal repo read
- ALLOW bounded source write
- DENY workflow write outside path scope
- DENY secret read
- ALLOW test command class
- DENY PR creation before approval
- ALLOW the same PR creation after task-bound approval
- DENY post-grant scope substitution at execution
- inspect a successful ActionTrace via `kernel.explain()`

The script drift-checks its semantic output against `examples/coding_agent_expected.txt`, and `make ci` now executes it.

`docs/coding-agent-security.md` explains the three practical authority profiles (review, edit+test, publish-for-review), the driver-side constraint requirement, and explicit non-claims.

## Scope

This does not pretend to solve arbitrary host sandboxing or prompt injection. The boundary only applies to actions routed through the embedded kernel and to drivers that enforce the signed constraints before the side effect.

This PR intentionally does not auto-close #253 yet; the issue can remain the canonical place for any richer action-envelope/budget/organizational-authority follow-up after this concrete beachhead is validated.

Merge only after the exact final head passes the repository's full CI.