### PR TITLE
feat: make coding-agent proof package-first

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,9 @@ jobs:
       - name: Run the README quickstart
         run: python examples/readme_quickstart.py
 
+      - name: Run the installed-package coding-agent proof
+        run: python -m weaver_kernel.coding_agent_demo
+
       - name: Assert optional extras are genuinely absent
         run: |
           for mod in mcp yaml opentelemetry tiktoken weaver_contracts; do

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Coding-agent least privilege (#253).** `CodingAgentPolicyEngine` introduces
+  narrow repository-read/write, local-test, network, secret, PR-create, and
+  PR-merge capabilities with role/task approval and signed path/command/task
+  scope. `python -m weaver_kernel.coding_agent_demo` is an installed-package,
+  hermetic proof of bounded read/edit/test, denied secret and out-of-scope
+  access, task-bound publish escalation, post-grant anti-swap enforcement, and
+  denial/success evidence through `kernel.explain()`.
 - **Fail-closed driver execution.** A grouped pass over the invocation path so
   the kernel's "controlled, audited execution" promise (I-02) holds on *every*
   exit, not just the happy path:

--- a/README.md
+++ b/README.md
@@ -16,6 +16,41 @@ and is uploaded as the `coverage-html-*` artifact. -->
 
 A capability-based security kernel for AI agents operating in large tool ecosystems (MCP, A2A, 1000+ tools).
 
+## Least privilege for coding agents
+
+Give an agent enough authority to read a repository, edit bounded paths, and
+run tests—without also granting secrets, workflow rewrites, network/package
+operations, or publishing authority.
+
+```mermaid
+flowchart TD
+    A["Coding-agent request"] --> K["weaver-kernel policy"]
+    K -->|denied| D["Explain or escalate"]
+    K -->|allowed| T["Signed scoped grant"]
+    T --> E["Driver executes"]
+    E --> R["ActionTrace receipt"]
+```
+
+> **Availability:** the direct module command ships in the first package
+> release containing [#253](https://github.com/dgenio/agent-kernel/issues/253).
+
+```bash
+python -m pip install weaver-kernel
+python -m weaver_kernel.coding_agent_demo
+```
+
+It runs a hermetic fake driver, prints only after all assertions pass, and visibly proves bounded
+read/edit/test, denied secret and out-of-scope access, explicit task-bound PR
+escalation, signed scope enforcement, and the corresponding `kernel.explain()`
+path. [Read the expected receipt and security boundaries.](docs/coding-agent-security.md)
+
+| Project | Use it for |
+| --- | --- |
+| **agent-kernel / `weaver-kernel`** | embedded capability authorization and audit |
+| [AgentFence](https://github.com/dgenio/AgentFence) | an external firewall at the tool boundary |
+| [ContextWeaver](https://github.com/dgenio/contextweaver) | bounded capability/context visibility |
+| ChainWeaver | deterministic multi-step execution |
+
 Every tool call gets a **capability token** (HMAC-signed, time-bounded, scoped to one principal and one capability) and a **tamper-evident audit trace** (`ActionTrace`) recording who invoked what, under which policy decision, with what result. That **authorization + audit** layer is `agent-kernel`'s unique contribution to the [Weaver stack](#part-of-the-weaver-stack) — neither `contextweaver` nor `AgentFence` provides it.
 
 ### Why `agent-kernel` and not `contextweaver` or `AgentFence`?

--- a/docs/coding-agent-security.md
+++ b/docs/coding-agent-security.md
@@ -1,34 +1,59 @@
 # Least privilege for coding agents
 
-`weaver-kernel` can give a coding agent useful repository and shell authority
-without turning that authority into an ambient "do anything" permission.
+`weaver-kernel` gives a coding agent useful repository and test authority
+without turning either into ambient permission to read secrets, rewrite CI, or
+publish work.
 
-The maintained flagship demo is network-free and makes no real repository or
-GitHub changes:
+The maintained flagship scenario is included in the package, is network-free,
+and makes no real filesystem or GitHub changes:
 
 ```bash
 python -m pip install weaver-kernel
-# From a source checkout of the matching release/commit:
-python examples/coding_agent_least_privilege.py
+python -m weaver_kernel.coding_agent_demo
 ```
+
+The direct module command is available in the first package release containing
+[#253](https://github.com/dgenio/agent-kernel/issues/253). From a checkout of
+that commit before the release, use `python -m pip install .` and run the same
+module command.
 
 Expected semantic receipt:
 
 ```text
-ALLOW repo.read.files README.md
-ALLOW repo.write.files src/demo.py
-DENY repo.write.files .github/workflows/release.yml
-DENY secrets.read .env
-ALLOW shell.run.tests command_class=test
-DENY github.create_pr task=ISSUE-253 before approval
-ALLOW github.create_pr task=ISSUE-253 after task-bound approval
-DENY scope substitution src/demo.py -> .github/workflows/release.yml at execution
-TRACE repo.read.files principal=coder driver=coding-agent
+ALLOW+EXECUTE repo.read.files path=README.md
+ALLOW+EXECUTE repo.write.files path=src/demo.py
+ALLOW+EXECUTE shell.run.tests command_class=test
+DENY repo.write.files path=.github/workflows/release.yml reason=scope_not_allowed
+DENY secrets.read path=.env reason=missing_role
+DENY github.create_pr task=ISSUE-253 reason=missing_attribute
+EXPLAIN deny capability=github.create_pr principal=coder reason=missing_attribute
+ESCALATE github.create_pr task=ISSUE-253 grant=one-task
+GRANT github.create_pr policy=CodingAgentPolicyEngine outcome=allowed bound=task_id
+ALLOW+EXECUTE github.create_pr task=ISSUE-253
+EXPLAIN invoke capability=github.create_pr principal=coder driver=coding-agent
+DENY scope-substitution path=src/demo.py -> .github/workflows/release.yml
 PASS: useful coding work stays usable while sensitive authority stays explicit.
 ```
 
-CI runs that exact demo and the script drift-checks the receipt against
-`examples/coding_agent_expected.txt`.
+The demo verifies every policy result and scope binding before printing. CI
+runs both the installed-package module and the source wrapper; the wrapper
+compares the output byte-for-byte with
+[`examples/coding_agent_expected.txt`](../examples/coding_agent_expected.txt).
+
+## What the trace proves
+
+The publish-for-review path deliberately shows four distinct facts:
+
+1. `github.create_pr` is denied without task-bound approval, producing a
+   `deny` `ActionTrace` with `reason=missing_attribute`.
+2. the host explicitly escalates by issuing a one-task principal attribute;
+3. the resulting policy grant binds `task_id` into the signed token; and
+4. after the fake driver executes, `kernel.explain()` returns the matching
+   successful invocation trace.
+
+That is a reproducible authorization and audit proof. It is not evidence that
+an LLM is trustworthy, and the demo driver intentionally performs no external
+side effect.
 
 ## Capability vocabulary
 
@@ -44,8 +69,8 @@ The built-in `CodingAgentPolicyEngine` intentionally starts small:
 | `github.create_pr` | requires an approval attribute bound to the exact task ID |
 | `github.merge_pr` | separately requires `admin` |
 
-This split is deliberate: permission to edit code does not imply permission to
-read credentials, access the network, create organizational work, or merge it.
+Permission to edit code does not imply permission to read credentials, access
+the network, create organizational work, or merge it.
 
 ## Signed scope, not grant-time theatre
 
@@ -66,35 +91,43 @@ If actual invocation arguments differ from the signed grant scope, execution
 fails closed. The flagship demo tests this substitution explicitly.
 
 The host is responsible for supplying normalized, trustworthy request scope
-(e.g. the actual repository-relative path or task ID) and the driver is
-responsible for calling the execution-side constraint helper before the side
-effect. Do not derive the trusted scope from LLM prose.
+(for example, the actual repository-relative path or task ID), and the driver
+must call the execution-side constraint helper before the side effect. Do not
+derive trusted scope from LLM prose.
 
 ## Three practical authority profiles
 
-You do not need three policy engines. Keep one policy and change which narrow
-roles/approvals the principal carries for the current phase:
+Keep one policy and change which narrow roles or approvals the principal
+carries for the current phase:
 
-- **Review:** no `code_writer` / `test_runner`; read normal repository files.
+- **Review:** read normal repository files; no `code_writer` or `test_runner`.
 - **Edit + test:** add `code_writer` and `test_runner`; writes remain limited to
-  configured path globs and shell authority remains the test category.
+  configured path globs and shell authority remains in the test category.
 - **Publish for review:** add a one-task `approved_task_id` attribute to permit
-  `github.create_pr`. This still does **not** grant merge authority.
+  `github.create_pr`. This still does not grant merge authority.
 
-Use a fresh/task-scoped principal or equivalent session claims when moving
+Use a fresh, task-scoped principal or equivalent session claims when moving
 between phases; do not accumulate permissions indefinitely.
 
-## What this is not
+## Boundaries and when not to use it
 
-- It is an **embedded authorization boundary** for actions your runtime routes
-  through `weaver-kernel`; it is not a VM/container sandbox.
-- It does not make the LLM trustworthy or prevent prompt injection. It limits
-  what a successful injection can do through mediated capabilities.
-- Drivers that ignore signed constraints can undermine scoped grants. Use the
-  provided helper (or an equivalently strict driver-specific check) before the
-  side effect.
-- If you only need a coarse external policy proxy around MCP traffic rather
-  than an embedded capability runtime, AgentFence may be the simpler boundary.
+| Project | Boundary |
+| --- | --- |
+| **agent-kernel / `weaver-kernel`** | embedded capability authorization, signed scope, execution audit |
+| **AgentFence** | external firewall at a tool/process boundary |
+| **ContextWeaver** | capability and context visibility/selection for the current phase |
+| **ChainWeaver** | deterministic multi-step execution |
+
+- This is not a VM or container sandbox. Use an OS/container isolation layer
+  when you need to contain arbitrary host process behavior.
+- It does not prevent prompt injection. It bounds mediated capabilities after
+  an injection or model mistake succeeds.
+- A driver that ignores signed constraints undermines scoped grants. Use the
+  provided helper or an equivalently strict driver-side check.
+- If you cannot change the agent host and only need an external MCP policy
+  boundary, AgentFence is the simpler fit.
+- If a small allowlist around a single fixed command is enough, a dedicated
+  wrapper may be simpler than adopting a capability runtime.
 
 For the general capability model see [Capabilities](capabilities.md); for hard
 runtime invariants see [Security](security.md) and

--- a/docs/coding-agent-security.md
+++ b/docs/coding-agent-security.md
@@ -109,6 +109,26 @@ carries for the current phase:
 Use a fresh, task-scoped principal or equivalent session claims when moving
 between phases; do not accumulate permissions indefinitely.
 
+## Nearby solutions
+
+An outsider usually searches for **coding-agent permissions**, **agent
+approvals**, or **agent sandboxing** rather than "capability kernel".
+
+- If every action stays inside one Codex or Claude Code session, use that
+  host's native [Codex sandbox and approval controls](https://developers.openai.com/codex/agent-approvals-security)
+  or [Claude Code permission rules](https://docs.anthropic.com/en/docs/claude-code/permissions).
+  They are simpler and also provide OS-level containment that `agent-kernel`
+  does not provide.
+- If the main requirement is organization-wide policy-as-code, use a mature
+  engine such as [Open Policy Agent](https://openpolicyagent.org/docs) or
+  [Cedar](https://docs.cedarpolicy.com/) instead of recreating its policy
+  language here.
+- Use `agent-kernel` when you are building the host and need one embedded,
+  host-neutral contract that turns a policy decision into a signed, narrowly
+  scoped grant, mediates the driver call, and records the result. A custom
+  `PolicyEngine` can delegate decisions to OPA or Cedar while retaining that
+  token, execution, firewall, and `ActionTrace` path.
+
 ## Boundaries and when not to use it
 
 | Project | Boundary |

--- a/examples/coding_agent_expected.txt
+++ b/examples/coding_agent_expected.txt
@@ -1,10 +1,13 @@
-ALLOW repo.read.files README.md
-ALLOW repo.write.files src/demo.py
-DENY repo.write.files .github/workflows/release.yml
-DENY secrets.read .env
-ALLOW shell.run.tests command_class=test
-DENY github.create_pr task=ISSUE-253 before approval
-ALLOW github.create_pr task=ISSUE-253 after task-bound approval
-DENY scope substitution src/demo.py -> .github/workflows/release.yml at execution
-TRACE repo.read.files principal=coder driver=coding-agent
+ALLOW+EXECUTE repo.read.files path=README.md
+ALLOW+EXECUTE repo.write.files path=src/demo.py
+ALLOW+EXECUTE shell.run.tests command_class=test
+DENY repo.write.files path=.github/workflows/release.yml reason=scope_not_allowed
+DENY secrets.read path=.env reason=missing_role
+DENY github.create_pr task=ISSUE-253 reason=missing_attribute
+EXPLAIN deny capability=github.create_pr principal=coder reason=missing_attribute
+ESCALATE github.create_pr task=ISSUE-253 grant=one-task
+GRANT github.create_pr policy=CodingAgentPolicyEngine outcome=allowed bound=task_id
+ALLOW+EXECUTE github.create_pr task=ISSUE-253
+EXPLAIN invoke capability=github.create_pr principal=coder driver=coding-agent
+DENY scope-substitution path=src/demo.py -> .github/workflows/release.yml
 PASS: useful coding work stays usable while sensitive authority stays explicit.

--- a/examples/coding_agent_least_privilege.py
+++ b/examples/coding_agent_least_privilege.py
@@ -1,225 +1,23 @@
-"""Deterministic coding-agent least-privilege flagship demo.
-
-Run with::
-
-    python examples/coding_agent_least_privilege.py
-
-The demo uses only the published ``weaver-kernel`` core package. No network,
-real filesystem mutation, GitHub token, or sibling Weaver project is required.
-"""
+"""Source-checkout wrapper for the installed-package coding-agent demo."""
 
 from __future__ import annotations
 
 import asyncio
-import os
 from pathlib import Path
 
-os.environ.setdefault("WEAVER_KERNEL_SECRET", "coding-agent-demo-not-for-production")
+from weaver_kernel.coding_agent_demo import run_demo
 
-from weaver_kernel import (
-    Capability,
-    CapabilityRegistry,
-    InMemoryDriver,
-    Kernel,
-    Principal,
-    SafetyClass,
-    SensitivityTag,
-    StaticRouter,
-)
-from weaver_kernel.coding_agent import (
-    CodingAgentPolicyEngine,
-    enforce_coding_agent_constraints,
-)
-from weaver_kernel.drivers.base import ExecutionContext
-from weaver_kernel.errors import DriverError, PolicyDenied
-from weaver_kernel.models import CapabilityRequest
-
-CAPABILITIES: tuple[tuple[str, SafetyClass, SensitivityTag], ...] = (
-    ("repo.read.files", SafetyClass.READ, SensitivityTag.NONE),
-    ("repo.write.files", SafetyClass.WRITE, SensitivityTag.NONE),
-    ("shell.run.tests", SafetyClass.WRITE, SensitivityTag.NONE),
-    ("shell.run.networked_command", SafetyClass.WRITE, SensitivityTag.NONE),
-    ("secrets.read", SafetyClass.READ, SensitivityTag.SECRETS),
-    ("github.create_pr", SafetyClass.WRITE, SensitivityTag.NONE),
-    ("github.merge_pr", SafetyClass.DESTRUCTIVE, SensitivityTag.NONE),
-)
 EXPECTED_RECEIPT = Path(__file__).with_name("coding_agent_expected.txt")
 
 
-def build_kernel() -> Kernel:
-    """Build a local kernel whose fake driver enforces signed grant scope."""
-    registry = CapabilityRegistry()
-    routes: dict[str, list[str]] = {}
-    driver = InMemoryDriver(driver_id="coding-agent")
-
-    def execute(ctx: ExecutionContext) -> dict[str, object]:
-        enforce_coding_agent_constraints(ctx.constraints, ctx.args)
-        return {"status": "executed", "capability": ctx.capability_id}
-
-    for capability_id, safety_class, sensitivity in CAPABILITIES:
-        registry.register(
-            Capability(
-                capability_id=capability_id,
-                name=capability_id,
-                description=f"Demo capability {capability_id}",
-                safety_class=safety_class,
-                sensitivity=sensitivity,
-            )
-        )
-        routes[capability_id] = ["coding-agent"]
-        driver.register_handler(capability_id, execute)
-
-    kernel = Kernel(
-        registry=registry,
-        policy=CodingAgentPolicyEngine(),
-        router=StaticRouter(routes=routes),
-    )
-    kernel.register_driver(driver)
-    return kernel
-
-
-def request(capability_id: str, **scope: str) -> CapabilityRequest:
-    """Create one host-normalized coding-agent request."""
-    return CapabilityRequest(
-        capability_id=capability_id,
-        goal=f"coding-agent demo: {capability_id}",
-        scope=scope,
-    )
-
-
-def record(receipt: list[str], line: str) -> None:
-    """Append one stable proof line and display it."""
-    receipt.append(line)
-    print(line)
-
-
-async def invoke_allowed(
-    kernel: Kernel,
-    principal: Principal,
-    capability_id: str,
-    *,
-    justification: str,
-    **scope: str,
-):
-    """Grant and invoke one action using the same exact scope arguments."""
-    token = kernel.get_token(
-        request(capability_id, **scope),
-        principal,
-        justification=justification,
-    )
-    frame = await kernel.invoke(token, principal=principal, args=dict(scope))
-    return token, frame
-
-
-async def main() -> None:
-    """Run the maintained ALLOW / DENY / escalation / anti-swap receipt."""
-    kernel = build_kernel()
-    coder = Principal(principal_id="coder", roles=["code_writer", "test_runner"])
-    receipt: list[str] = []
-
-    _, read_frame = await invoke_allowed(
-        kernel,
-        coder,
-        "repo.read.files",
-        path="README.md",
-        justification="Review the repository README",
-    )
-    record(receipt, "ALLOW repo.read.files README.md")
-
-    write_token, _ = await invoke_allowed(
-        kernel,
-        coder,
-        "repo.write.files",
-        path="src/demo.py",
-        justification="Edit source for the approved task",
-    )
-    record(receipt, "ALLOW repo.write.files src/demo.py")
-
-    try:
-        kernel.get_token(
-            request("repo.write.files", path=".github/workflows/release.yml"),
-            coder,
-            justification="Change the release workflow",
-        )
-    except PolicyDenied:
-        record(receipt, "DENY repo.write.files .github/workflows/release.yml")
-    else:  # pragma: no cover - defensive
-        raise AssertionError("workflow mutation unexpectedly received a grant")
-
-    try:
-        kernel.get_token(
-            request("secrets.read", path=".env"),
-            coder,
-            justification="Read environment credentials",
-        )
-    except PolicyDenied:
-        record(receipt, "DENY secrets.read .env")
-    else:  # pragma: no cover - defensive
-        raise AssertionError("secret access unexpectedly received a grant")
-
-    await invoke_allowed(
-        kernel,
-        coder,
-        "shell.run.tests",
-        command_class="test",
-        justification="Run the local test suite",
-    )
-    record(receipt, "ALLOW shell.run.tests command_class=test")
-
-    task_id = "ISSUE-253"
-    try:
-        kernel.get_token(
-            request("github.create_pr", task_id=task_id),
-            coder,
-            justification="Publish the completed task for review",
-        )
-    except PolicyDenied:
-        record(receipt, "DENY github.create_pr task=ISSUE-253 before approval")
-    else:  # pragma: no cover - defensive
-        raise AssertionError("PR creation unexpectedly bypassed task approval")
-
-    approved_coder = Principal(
-        principal_id="coder",
-        roles=list(coder.roles),
-        attributes={"approved_task_id": task_id},
-    )
-    await invoke_allowed(
-        kernel,
-        approved_coder,
-        "github.create_pr",
-        task_id=task_id,
-        justification="Create the explicitly approved PR",
-    )
-    record(receipt, "ALLOW github.create_pr task=ISSUE-253 after task-bound approval")
-
-    try:
-        await kernel.invoke(
-            write_token,
-            principal=coder,
-            args={"path": ".github/workflows/release.yml"},
-        )
-    except DriverError:
-        record(
-            receipt,
-            "DENY scope substitution src/demo.py -> .github/workflows/release.yml at execution",
-        )
-    else:  # pragma: no cover - defensive
-        raise AssertionError("signed write scope was not enforced by the driver boundary")
-
-    trace = kernel.explain(read_frame.action_id)
-    assert trace.capability_id == "repo.read.files"
-    assert trace.principal_id == "coder"
-    assert trace.driver_id == "coding-agent"
-    record(receipt, "TRACE repo.read.files principal=coder driver=coding-agent")
-    record(
-        receipt,
-        "PASS: useful coding work stays usable while sensitive authority stays explicit.",
-    )
-
+def main() -> None:
+    """Verify the package demo against the committed receipt before printing."""
+    receipt = asyncio.run(run_demo())
     actual = "\n".join(receipt) + "\n"
     expected = EXPECTED_RECEIPT.read_text(encoding="utf-8")
-    assert actual == expected, "coding-agent flagship receipt drifted from its maintained fixture"
+    assert actual == expected, "coding-agent flagship receipt fixture drifted"
+    print(actual, end="")
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    main()

--- a/src/weaver_kernel/coding_agent_demo.py
+++ b/src/weaver_kernel/coding_agent_demo.py
@@ -1,0 +1,281 @@
+"""Installed-package proof of least privilege for coding agents.
+
+Run the maintained, hermetic scenario with::
+
+    python -m weaver_kernel.coding_agent_demo
+
+The fake driver performs no filesystem, network, package, or GitHub side
+effects. The proof is about authorization, signed scope enforcement, and the
+audit path that a real driver must mediate before performing those effects.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+from .coding_agent import CodingAgentPolicyEngine, enforce_coding_agent_constraints
+from .drivers.base import ExecutionContext
+from .drivers.memory import InMemoryDriver
+from .enums import SafetyClass, SensitivityTag
+from .errors import DriverError, PolicyDenied
+from .kernel import Kernel
+from .models import (
+    ActionTrace,
+    Capability,
+    CapabilityGrant,
+    CapabilityRequest,
+    Frame,
+    Principal,
+    TraceEventType,
+)
+from .policy_reasons import DenialReason
+from .registry import CapabilityRegistry
+from .router import StaticRouter
+
+os.environ.setdefault("WEAVER_KERNEL_SECRET", "coding-agent-demo-not-for-production")
+
+_CAPABILITIES: tuple[tuple[str, SafetyClass, SensitivityTag], ...] = (
+    ("repo.read.files", SafetyClass.READ, SensitivityTag.NONE),
+    ("repo.write.files", SafetyClass.WRITE, SensitivityTag.NONE),
+    ("shell.run.tests", SafetyClass.WRITE, SensitivityTag.NONE),
+    ("shell.run.networked_command", SafetyClass.WRITE, SensitivityTag.NONE),
+    ("secrets.read", SafetyClass.READ, SensitivityTag.SECRETS),
+    ("github.create_pr", SafetyClass.WRITE, SensitivityTag.NONE),
+    ("github.merge_pr", SafetyClass.DESTRUCTIVE, SensitivityTag.NONE),
+)
+
+EXPECTED_RECEIPT: tuple[str, ...] = (
+    "ALLOW+EXECUTE repo.read.files path=README.md",
+    "ALLOW+EXECUTE repo.write.files path=src/demo.py",
+    "ALLOW+EXECUTE shell.run.tests command_class=test",
+    "DENY repo.write.files path=.github/workflows/release.yml reason=scope_not_allowed",
+    "DENY secrets.read path=.env reason=missing_role",
+    "DENY github.create_pr task=ISSUE-253 reason=missing_attribute",
+    "EXPLAIN deny capability=github.create_pr principal=coder reason=missing_attribute",
+    "ESCALATE github.create_pr task=ISSUE-253 grant=one-task",
+    "GRANT github.create_pr policy=CodingAgentPolicyEngine outcome=allowed bound=task_id",
+    "ALLOW+EXECUTE github.create_pr task=ISSUE-253",
+    "EXPLAIN invoke capability=github.create_pr principal=coder driver=coding-agent",
+    "DENY scope-substitution path=src/demo.py -> .github/workflows/release.yml",
+    "PASS: useful coding work stays usable while sensitive authority stays explicit.",
+)
+
+
+def _build_kernel() -> Kernel:
+    registry = CapabilityRegistry()
+    routes: dict[str, list[str]] = {}
+    driver = InMemoryDriver(driver_id="coding-agent")
+
+    def execute(ctx: ExecutionContext) -> dict[str, object]:
+        enforce_coding_agent_constraints(ctx.constraints, ctx.args)
+        return {"status": "executed", "capability": ctx.capability_id}
+
+    for capability_id, safety_class, sensitivity in _CAPABILITIES:
+        registry.register(
+            Capability(
+                capability_id=capability_id,
+                name=capability_id,
+                description=f"Demo capability {capability_id}",
+                safety_class=safety_class,
+                sensitivity=sensitivity,
+            )
+        )
+        routes[capability_id] = ["coding-agent"]
+        driver.register_handler(capability_id, execute)
+
+    kernel = Kernel(
+        registry=registry,
+        policy=CodingAgentPolicyEngine(),
+        router=StaticRouter(routes=routes),
+    )
+    kernel.register_driver(driver)
+    return kernel
+
+
+def _request(capability_id: str, **scope: str) -> CapabilityRequest:
+    return CapabilityRequest(
+        capability_id=capability_id,
+        goal=f"coding-agent demo: {capability_id}",
+        scope=scope,
+    )
+
+
+async def _grant_and_invoke(
+    kernel: Kernel,
+    principal: Principal,
+    capability_id: str,
+    *,
+    justification: str,
+    **scope: str,
+) -> tuple[CapabilityGrant, Frame]:
+    grant = kernel.grant_capability(
+        _request(capability_id, **scope),
+        principal,
+        justification=justification,
+    )
+    frame = await kernel.invoke(grant.token, principal=principal, args=dict(scope))
+    return grant, frame
+
+
+def _latest_trace(
+    kernel: Kernel,
+    *,
+    capability_id: str,
+    event_type: TraceEventType,
+) -> ActionTrace:
+    matches = [
+        trace
+        for trace in kernel.list_traces()
+        if trace.capability_id == capability_id and trace.event_type == event_type
+    ]
+    assert matches, f"missing {event_type} trace for {capability_id}"
+    return kernel.explain(matches[-1].action_id)
+
+
+async def run_demo() -> tuple[str, ...]:
+    """Run the maintained proof and return its verified semantic receipt."""
+    kernel = _build_kernel()
+    coder = Principal(principal_id="coder", roles=["code_writer", "test_runner"])
+    receipt: list[str] = []
+
+    _, _ = await _grant_and_invoke(
+        kernel,
+        coder,
+        "repo.read.files",
+        path="README.md",
+        justification="Review the repository README",
+    )
+    receipt.append("ALLOW+EXECUTE repo.read.files path=README.md")
+
+    write_grant, _ = await _grant_and_invoke(
+        kernel,
+        coder,
+        "repo.write.files",
+        path="src/demo.py",
+        justification="Edit source for the approved task",
+    )
+    receipt.append("ALLOW+EXECUTE repo.write.files path=src/demo.py")
+
+    _, _ = await _grant_and_invoke(
+        kernel,
+        coder,
+        "shell.run.tests",
+        command_class="test",
+        justification="Run the local test suite",
+    )
+    receipt.append("ALLOW+EXECUTE shell.run.tests command_class=test")
+
+    try:
+        kernel.get_token(
+            _request("repo.write.files", path=".github/workflows/release.yml"),
+            coder,
+            justification="Change the release workflow",
+        )
+    except PolicyDenied as exc:
+        assert exc.reason_code == DenialReason.SCOPE_NOT_ALLOWED
+        receipt.append(
+            "DENY repo.write.files path=.github/workflows/release.yml "
+            "reason=scope_not_allowed"
+        )
+    else:  # pragma: no cover - defensive
+        raise AssertionError("workflow mutation unexpectedly received a grant")
+
+    try:
+        kernel.get_token(
+            _request("secrets.read", path=".env"),
+            coder,
+            justification="Read environment credentials",
+        )
+    except PolicyDenied as exc:
+        assert exc.reason_code == DenialReason.MISSING_ROLE
+        receipt.append("DENY secrets.read path=.env reason=missing_role")
+    else:  # pragma: no cover - defensive
+        raise AssertionError("secret access unexpectedly received a grant")
+
+    task_id = "ISSUE-253"
+    try:
+        kernel.get_token(
+            _request("github.create_pr", task_id=task_id),
+            coder,
+            justification="Publish the completed task for review",
+        )
+    except PolicyDenied as exc:
+        assert exc.reason_code == DenialReason.MISSING_ATTRIBUTE
+        receipt.append("DENY github.create_pr task=ISSUE-253 reason=missing_attribute")
+    else:  # pragma: no cover - defensive
+        raise AssertionError("PR creation unexpectedly bypassed task approval")
+
+    denial_trace = _latest_trace(
+        kernel,
+        capability_id="github.create_pr",
+        event_type="deny",
+    )
+    assert denial_trace.principal_id == "coder"
+    assert denial_trace.reason_code == DenialReason.MISSING_ATTRIBUTE
+    receipt.append(
+        "EXPLAIN deny capability=github.create_pr principal=coder reason=missing_attribute"
+    )
+
+    receipt.append("ESCALATE github.create_pr task=ISSUE-253 grant=one-task")
+    approved_coder = Principal(
+        principal_id="coder",
+        roles=list(coder.roles),
+        attributes={"approved_task_id": task_id},
+    )
+    pr_grant, pr_frame = await _grant_and_invoke(
+        kernel,
+        approved_coder,
+        "github.create_pr",
+        task_id=task_id,
+        justification="Create the explicitly approved PR",
+    )
+    policy_trace = pr_grant.decision.trace
+    assert policy_trace is not None
+    assert policy_trace.engine == "CodingAgentPolicyEngine"
+    assert policy_trace.final_outcome == "allowed"
+    assert pr_grant.token.constraints == {"coding_agent": {"task_id": task_id}}
+    receipt.append(
+        "GRANT github.create_pr policy=CodingAgentPolicyEngine "
+        "outcome=allowed bound=task_id"
+    )
+    receipt.append("ALLOW+EXECUTE github.create_pr task=ISSUE-253")
+
+    invocation_trace = kernel.explain(pr_frame.action_id)
+    assert invocation_trace.event_type == "invoke"
+    assert invocation_trace.capability_id == "github.create_pr"
+    assert invocation_trace.principal_id == "coder"
+    assert invocation_trace.driver_id == "coding-agent"
+    receipt.append(
+        "EXPLAIN invoke capability=github.create_pr principal=coder driver=coding-agent"
+    )
+
+    try:
+        await kernel.invoke(
+            write_grant.token,
+            principal=coder,
+            args={"path": ".github/workflows/release.yml"},
+        )
+    except DriverError:
+        receipt.append(
+            "DENY scope-substitution path=src/demo.py -> .github/workflows/release.yml"
+        )
+    else:  # pragma: no cover - defensive
+        raise AssertionError("signed write scope was not enforced by the driver boundary")
+
+    receipt.append(
+        "PASS: useful coding work stays usable while sensitive authority stays explicit."
+    )
+    actual = tuple(receipt)
+    assert actual == EXPECTED_RECEIPT, "coding-agent flagship receipt drifted"
+    return actual
+
+
+def main() -> None:
+    """Run the demo, verify every assertion, then print the maintained receipt."""
+    receipt = asyncio.run(run_demo())
+    print("\n".join(receipt))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/weaver_kernel/coding_agent_demo.py
+++ b/src/weaver_kernel/coding_agent_demo.py
@@ -12,7 +12,6 @@ audit path that a real driver must mediate before performing those effects.
 from __future__ import annotations
 
 import asyncio
-import os
 
 from .coding_agent import CodingAgentPolicyEngine, enforce_coding_agent_constraints
 from .drivers.base import ExecutionContext
@@ -32,8 +31,7 @@ from .models import (
 from .policy_reasons import DenialReason
 from .registry import CapabilityRegistry
 from .router import StaticRouter
-
-os.environ.setdefault("WEAVER_KERNEL_SECRET", "coding-agent-demo-not-for-production")
+from .tokens import HMACTokenProvider
 
 _CAPABILITIES: tuple[tuple[str, SafetyClass, SensitivityTag], ...] = (
     ("repo.read.files", SafetyClass.READ, SensitivityTag.NONE),
@@ -88,6 +86,7 @@ def _build_kernel() -> Kernel:
         registry=registry,
         policy=CodingAgentPolicyEngine(),
         router=StaticRouter(routes=routes),
+        token_provider=HMACTokenProvider(secret="coding-agent-demo-not-for-production"),
     )
     kernel.register_driver(driver)
     return kernel
@@ -139,7 +138,7 @@ async def run_demo() -> tuple[str, ...]:
     coder = Principal(principal_id="coder", roles=["code_writer", "test_runner"])
     receipt: list[str] = []
 
-    _, _ = await _grant_and_invoke(
+    await _grant_and_invoke(
         kernel,
         coder,
         "repo.read.files",
@@ -157,7 +156,7 @@ async def run_demo() -> tuple[str, ...]:
     )
     receipt.append("ALLOW+EXECUTE repo.write.files path=src/demo.py")
 
-    _, _ = await _grant_and_invoke(
+    await _grant_and_invoke(
         kernel,
         coder,
         "shell.run.tests",

--- a/src/weaver_kernel/coding_agent_demo.py
+++ b/src/weaver_kernel/coding_agent_demo.py
@@ -174,8 +174,7 @@ async def run_demo() -> tuple[str, ...]:
     except PolicyDenied as exc:
         assert exc.reason_code == DenialReason.SCOPE_NOT_ALLOWED
         receipt.append(
-            "DENY repo.write.files path=.github/workflows/release.yml "
-            "reason=scope_not_allowed"
+            "DENY repo.write.files path=.github/workflows/release.yml reason=scope_not_allowed"
         )
     else:  # pragma: no cover - defensive
         raise AssertionError("workflow mutation unexpectedly received a grant")
@@ -235,8 +234,7 @@ async def run_demo() -> tuple[str, ...]:
     assert policy_trace.final_outcome == "allowed"
     assert pr_grant.token.constraints == {"coding_agent": {"task_id": task_id}}
     receipt.append(
-        "GRANT github.create_pr policy=CodingAgentPolicyEngine "
-        "outcome=allowed bound=task_id"
+        "GRANT github.create_pr policy=CodingAgentPolicyEngine outcome=allowed bound=task_id"
     )
     receipt.append("ALLOW+EXECUTE github.create_pr task=ISSUE-253")
 
@@ -256,9 +254,7 @@ async def run_demo() -> tuple[str, ...]:
             args={"path": ".github/workflows/release.yml"},
         )
     except DriverError:
-        receipt.append(
-            "DENY scope-substitution path=src/demo.py -> .github/workflows/release.yml"
-        )
+        receipt.append("DENY scope-substitution path=src/demo.py -> .github/workflows/release.yml")
     else:  # pragma: no cover - defensive
         raise AssertionError("signed write scope was not enforced by the driver boundary")
 

--- a/src/weaver_kernel/coding_agent_demo.py
+++ b/src/weaver_kernel/coding_agent_demo.py
@@ -17,7 +17,7 @@ from .coding_agent import CodingAgentPolicyEngine, enforce_coding_agent_constrai
 from .drivers.base import ExecutionContext
 from .drivers.memory import InMemoryDriver
 from .enums import SafetyClass, SensitivityTag
-from .errors import DriverError, PolicyDenied
+from .errors import AgentKernelError, DriverError, PolicyDenied
 from .kernel import Kernel
 from .models import (
     ActionTrace,
@@ -133,7 +133,16 @@ def _latest_trace(
 
 
 async def run_demo() -> tuple[str, ...]:
-    """Run the maintained proof and return its verified semantic receipt."""
+    """Run the maintained proof and return its verified semantic receipt.
+
+    Raises:
+        AgentKernelError: If Python optimization disabled the assertions that
+            make this executable proof fail closed.
+    """
+    if not __debug__:
+        raise AgentKernelError(
+            "The coding-agent demo requires Python assertions; rerun without -O."
+        )
     kernel = _build_kernel()
     coder = Principal(principal_id="coder", roles=["code_writer", "test_runner"])
     receipt: list[str] = []

--- a/tests/test_coding_agent_demo.py
+++ b/tests/test_coding_agent_demo.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import subprocess
+import sys
+
 import pytest
 
 from weaver_kernel.coding_agent_demo import EXPECTED_RECEIPT, main
@@ -14,3 +17,15 @@ def test_demo_verifies_before_emitting_exact_receipt(
     captured = capsys.readouterr()
     assert captured.out == "\n".join(EXPECTED_RECEIPT) + "\n"
     assert captured.err == ""
+
+
+def test_demo_refuses_optimized_python_before_printing() -> None:
+    completed = subprocess.run(
+        [sys.executable, "-O", "-m", "weaver_kernel.coding_agent_demo"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode != 0
+    assert completed.stdout == ""
+    assert "requires Python assertions; rerun without -O" in completed.stderr

--- a/tests/test_coding_agent_demo.py
+++ b/tests/test_coding_agent_demo.py
@@ -1,0 +1,16 @@
+"""Regression tests for the installed-package coding-agent proof."""
+
+from __future__ import annotations
+
+import pytest
+
+from weaver_kernel.coding_agent_demo import EXPECTED_RECEIPT, main
+
+
+def test_demo_verifies_before_emitting_exact_receipt(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    main()
+    captured = capsys.readouterr()
+    assert captured.out == "\n".join(EXPECTED_RECEIPT) + "\n"
+    assert captured.err == ""


### PR DESCRIPTION
Follow-up to #273; advances #253 without replacing the merged policy work.

## Why

The initial flagship proved the capability boundary from a source checkout, but two adoption requirements remained:

- the first success was not executable directly from an installed `weaver-kernel` package;
- `kernel.explain()` showed only an unrelated successful read rather than the complete publish escalation path.

## What changes

- adds `python -m weaver_kernel.coding_agent_demo` as a hermetic installed-package proof;
- keeps the source example as a tiny wrapper over the package module;
- verifies the exact receipt before printing and drift-checks it against the committed fixture;
- shows bounded read/edit/test, denied workflow and secret access, denied PR creation, explicit one-task escalation, a signed task-bound grant, successful execution, denial and invoke traces through `kernel.explain()`, and post-grant scope-substitution denial;
- runs the module in the no-extras `pip install .` CI lane;
- gives the README a coding-agent hero, clear sibling boundaries, and explicit release availability;
- records the feature in the changelog.

## Security boundary

The demo uses an in-memory fake driver and performs no filesystem, network, package, or GitHub side effects. It proves embedded authorization, signed scope enforcement, and audit behavior only. It is not a sandbox and does not prevent prompt injection.

Merge only after the exact final head passes full CI and CodeQL.