### PR TITLE
fix: fail closed on unclassified MCP tools

### DIFF
--- a/docs/mcp-safety-classification.md
+++ b/docs/mcp-safety-classification.md
@@ -1,0 +1,76 @@
+# MCP tool safety classification
+
+`MCPDriver.discover()` treats MCP tool annotations as **advisory metadata**, not as trusted authorization input.
+
+## Default: reject missing safety metadata
+
+A tool that has neither:
+
+- an explicit operator classification in `safety_class_map`, nor
+- a useful MCP `readOnlyHint` / `destructiveHint`
+
+is rejected by default rather than silently becoming `SafetyClass.READ`.
+
+```python
+from weaver_kernel import SafetyClass
+
+capabilities = await driver.discover(
+    namespace="github",
+    safety_class_map={
+        "list_issues": SafetyClass.READ,
+        "create_issue": SafetyClass.WRITE,
+        "delete_repository": SafetyClass.DESTRUCTIVE,
+    },
+)
+```
+
+If any discovered tool remains unclassified, discovery raises `DriverError` and names every affected tool. This makes missing metadata visible before the capabilities are registered or invoked.
+
+## Explicit fallback
+
+For a controlled environment where an operator deliberately wants one fallback class, opt in explicitly:
+
+```python
+capabilities = await driver.discover(
+    unannotated_safety=SafetyClass.WRITE,
+)
+```
+
+Kernel logs a warning naming each tool that received the fallback. Choosing a fallback is an operator decision; it is never inferred from the absence of metadata.
+
+To preserve the previous pre-#181 behavior deliberately, an adopter may pass:
+
+```python
+capabilities = await driver.discover(
+    unannotated_safety=SafetyClass.READ,
+)
+```
+
+That opt-back should be reviewed carefully: `READ` is the least-restricted default safety class and an MCP server can expose tools whose names or descriptions understate their side effects.
+
+## Precedence
+
+Classification uses this order:
+
+1. explicit `safety_class_map[tool_name]` supplied by the operator;
+2. `destructiveHint=True` → `DESTRUCTIVE`;
+3. `readOnlyHint=True` → `READ`;
+4. explicit `unannotated_safety` fallback, if configured;
+5. otherwise reject.
+
+If a server supplies conflicting read-only and destructive hints, destructive wins.
+
+## Security boundary
+
+This change prevents **missing MCP metadata** from silently granting READ-level authority. It does not make MCP annotations trustworthy. A compromised or incorrect server can still mislabel a destructive tool as read-only.
+
+For high-assurance deployments, treat the operator-maintained classification map (or an equivalent reviewed policy artifact) as the authoritative safety classification. Combine classification with normal principal/capability policy, token constraints and the execution/audit boundary described in [`security.md`](security.md).
+
+## Migration from earlier releases
+
+Earlier versions inferred `READ` when annotations were absent. Code that relied on that behavior must now choose one of two explicit migrations:
+
+- **recommended:** classify tools by name with `safety_class_map`;
+- **compatibility opt-back:** set `unannotated_safety=SafetyClass.READ` and accept the warning/audit implications.
+
+This is a deliberate fail-closed breaking change for a security-sensitive default.

--- a/src/weaver_kernel/drivers/mcp.py
+++ b/src/weaver_kernel/drivers/mcp.py
@@ -3,28 +3,22 @@
 from __future__ import annotations
 
 import importlib
-import logging
 from collections.abc import Awaitable, Callable
-from typing import Any, Literal
+from typing import Any
 
 from ..enums import SafetyClass
 from ..errors import DriverError
 from ..models import Capability, ImplementationRef, RawResult
 from .base import ExecutionContext
+from .mcp_classification import UnannotatedSafety, classify_tool_specs
 from .mcp_support import (
     SessionFactory,
-    ToolSpec,
     build_http_session_factory,
     build_stdio_session_factory,
     call_tool,
     extract_tool_specs,
     normalize_call_result,
 )
-
-logger = logging.getLogger(__name__)
-
-UnannotatedSafety = SafetyClass | Literal["reject"]
-"""How discovery handles a tool with no usable MCP safety annotation."""
 
 
 def _load_mcp_error() -> type[BaseException] | None:
@@ -55,21 +49,6 @@ def _load_mcp_error() -> type[BaseException] | None:
 # dependency is not installed (factory methods raise ImportError first, so this
 # is never None on a live driver instance).
 _McpError: type[BaseException] | None = _load_mcp_error()
-
-
-def _infer_safety_class(spec: ToolSpec) -> SafetyClass | None:
-    """Infer a ``SafetyClass`` only from explicit MCP ToolAnnotations hints.
-
-    MCP annotations are advisory metadata, not an authorization statement. A
-    destructive hint wins over a read-only hint. When neither useful hint is
-    present, return ``None`` so the caller must reject or apply an explicitly
-    configured fallback instead of silently treating the tool as READ.
-    """
-    if spec.destructive_hint:
-        return SafetyClass.DESTRUCTIVE
-    if spec.read_only_hint:
-        return SafetyClass.READ
-    return None
 
 
 class MCPDriver:
@@ -149,53 +128,24 @@ class MCPDriver:
         """Discover MCP tools and convert them to deliberately classified capabilities.
 
         Explicit ``safety_class_map`` entries take precedence over advisory MCP
-        annotations. A tool with neither an explicit override nor a useful MCP
-        safety hint is rejected by default. Callers that knowingly accept a
-        fallback may pass a ``SafetyClass`` via ``unannotated_safety``; doing so
-        emits a warning naming every tool that received that fallback.
-
-        Args:
-            namespace: Optional capability-id namespace.
-            safety_class_map: Explicit per-tool classifications supplied by the
-                operator. These are trusted configuration and override MCP hints.
-            unannotated_safety: ``"reject"`` (default) or an explicit fallback
-                ``SafetyClass`` for otherwise unclassified tools.
-
-        Raises:
-            DriverError: If ``unannotated_safety`` is invalid or one or more tools
-                remain unclassified while the mode is ``"reject"``.
+        annotations. Tools with neither an override nor a useful annotation are
+        rejected by default. Pass a ``SafetyClass`` via ``unannotated_safety``
+        only when an operator deliberately accepts one fallback classification.
         """
-        if unannotated_safety != "reject" and not isinstance(unannotated_safety, SafetyClass):
-            raise DriverError(
-                "unannotated_safety must be 'reject' or a SafetyClass, "
-                f"got {unannotated_safety!r}."
-            )
-
         tools = await self._run_with_retry(
             operation_name="tools/list",
             action=self._fetch_all_tools,
         )
+        classified = classify_tool_specs(
+            extract_tool_specs(tools),
+            driver_id=self._driver_id,
+            safety_class_map=safety_class_map,
+            unannotated_safety=unannotated_safety,
+        )
 
         capabilities: list[Capability] = []
-        rejected_tools: list[str] = []
-        fallback_tools: list[str] = []
-
-        for spec in extract_tool_specs(tools):
+        for spec, safety_class in classified:
             capability_id = f"{namespace}.{spec.name}" if namespace else spec.name
-
-            if safety_class_map is not None and spec.name in safety_class_map:
-                safety_class = safety_class_map[spec.name]
-            else:
-                inferred = _infer_safety_class(spec)
-                if inferred is not None:
-                    safety_class = inferred
-                elif unannotated_safety == "reject":
-                    rejected_tools.append(spec.name)
-                    continue
-                else:
-                    safety_class = unannotated_safety
-                    fallback_tools.append(spec.name)
-
             capabilities.append(
                 Capability(
                     capability_id=capability_id,
@@ -209,24 +159,6 @@ class MCPDriver:
                     ),
                 )
             )
-
-        if rejected_tools:
-            names = ", ".join(sorted(rejected_tools))
-            raise DriverError(
-                f"MCPDriver '{self._driver_id}' refused to auto-register unclassified "
-                f"tools: {names}. Classify them with safety_class_map or explicitly "
-                "set unannotated_safety to a SafetyClass. MCP annotations are advisory "
-                "and missing metadata is not treated as READ authority."
-            )
-
-        if fallback_tools:
-            logger.warning(
-                "mcp_unannotated_safety_fallback driver_id=%s safety_class=%s tools=%s",
-                self._driver_id,
-                unannotated_safety.value,
-                ",".join(sorted(fallback_tools)),
-            )
-
         return capabilities
 
     async def _fetch_all_tools(self, session: Any) -> list[Any]:

--- a/src/weaver_kernel/drivers/mcp.py
+++ b/src/weaver_kernel/drivers/mcp.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import importlib
+import logging
 from collections.abc import Awaitable, Callable
-from typing import Any
+from typing import Any, Literal
 
 from ..enums import SafetyClass
 from ..errors import DriverError
@@ -19,6 +20,11 @@ from .mcp_support import (
     extract_tool_specs,
     normalize_call_result,
 )
+
+logger = logging.getLogger(__name__)
+
+UnannotatedSafety = SafetyClass | Literal["reject"]
+"""How discovery handles a tool with no usable MCP safety annotation."""
 
 
 def _load_mcp_error() -> type[BaseException] | None:
@@ -51,17 +57,19 @@ def _load_mcp_error() -> type[BaseException] | None:
 _McpError: type[BaseException] | None = _load_mcp_error()
 
 
-def _infer_safety_class(spec: ToolSpec) -> SafetyClass:
-    """Infer a SafetyClass from MCP ToolAnnotations hints.
+def _infer_safety_class(spec: ToolSpec) -> SafetyClass | None:
+    """Infer a ``SafetyClass`` only from explicit MCP ToolAnnotations hints.
 
-    Uses a conservative default of READ when annotations are absent.
-    The caller's safety_class_map takes precedence over the inferred value.
+    MCP annotations are advisory metadata, not an authorization statement. A
+    destructive hint wins over a read-only hint. When neither useful hint is
+    present, return ``None`` so the caller must reject or apply an explicitly
+    configured fallback instead of silently treating the tool as READ.
     """
     if spec.destructive_hint:
         return SafetyClass.DESTRUCTIVE
     if spec.read_only_hint:
         return SafetyClass.READ
-    return SafetyClass.READ
+    return None
 
 
 class MCPDriver:
@@ -136,22 +144,58 @@ class MCPDriver:
         *,
         namespace: str | None = None,
         safety_class_map: dict[str, SafetyClass] | None = None,
+        unannotated_safety: UnannotatedSafety = "reject",
     ) -> list[Capability]:
-        """Discover MCP tools across all pages and convert them to capabilities."""
+        """Discover MCP tools and convert them to deliberately classified capabilities.
+
+        Explicit ``safety_class_map`` entries take precedence over advisory MCP
+        annotations. A tool with neither an explicit override nor a useful MCP
+        safety hint is rejected by default. Callers that knowingly accept a
+        fallback may pass a ``SafetyClass`` via ``unannotated_safety``; doing so
+        emits a warning naming every tool that received that fallback.
+
+        Args:
+            namespace: Optional capability-id namespace.
+            safety_class_map: Explicit per-tool classifications supplied by the
+                operator. These are trusted configuration and override MCP hints.
+            unannotated_safety: ``"reject"`` (default) or an explicit fallback
+                ``SafetyClass`` for otherwise unclassified tools.
+
+        Raises:
+            DriverError: If ``unannotated_safety`` is invalid or one or more tools
+                remain unclassified while the mode is ``"reject"``.
+        """
+        if unannotated_safety != "reject" and not isinstance(unannotated_safety, SafetyClass):
+            raise DriverError(
+                "unannotated_safety must be 'reject' or a SafetyClass, "
+                f"got {unannotated_safety!r}."
+            )
+
         tools = await self._run_with_retry(
             operation_name="tools/list",
             action=self._fetch_all_tools,
         )
 
         capabilities: list[Capability] = []
+        rejected_tools: list[str] = []
+        fallback_tools: list[str] = []
+
         for spec in extract_tool_specs(tools):
             capability_id = f"{namespace}.{spec.name}" if namespace else spec.name
-            inferred = _infer_safety_class(spec)
-            safety_class = (
-                safety_class_map.get(spec.name, inferred)
-                if safety_class_map is not None
-                else inferred
-            )
+
+            if safety_class_map is not None and spec.name in safety_class_map:
+                safety_class = safety_class_map[spec.name]
+            else:
+                inferred = _infer_safety_class(spec)
+                if inferred is not None:
+                    safety_class = inferred
+                elif unannotated_safety == "reject":
+                    rejected_tools.append(spec.name)
+                    continue
+                else:
+                    safety_class = unannotated_safety
+                    fallback_tools.append(spec.name)
+
             capabilities.append(
                 Capability(
                     capability_id=capability_id,
@@ -165,6 +209,24 @@ class MCPDriver:
                     ),
                 )
             )
+
+        if rejected_tools:
+            names = ", ".join(sorted(rejected_tools))
+            raise DriverError(
+                f"MCPDriver '{self._driver_id}' refused to auto-register unclassified "
+                f"tools: {names}. Classify them with safety_class_map or explicitly "
+                "set unannotated_safety to a SafetyClass. MCP annotations are advisory "
+                "and missing metadata is not treated as READ authority."
+            )
+
+        if fallback_tools:
+            logger.warning(
+                "mcp_unannotated_safety_fallback driver_id=%s safety_class=%s tools=%s",
+                self._driver_id,
+                unannotated_safety.value,
+                ",".join(sorted(fallback_tools)),
+            )
+
         return capabilities
 
     async def _fetch_all_tools(self, session: Any) -> list[Any]:

--- a/src/weaver_kernel/drivers/mcp_classification.py
+++ b/src/weaver_kernel/drivers/mcp_classification.py
@@ -53,7 +53,12 @@ def classify_tool_specs(
 
     for spec in specs:
         if safety_class_map is not None and spec.name in safety_class_map:
-            safety_class = safety_class_map[spec.name]
+            configured = safety_class_map[spec.name]
+            if not isinstance(configured, SafetyClass):
+                raise DriverError(
+                    f"safety_class_map[{spec.name!r}] must be a SafetyClass, got {configured!r}."
+                )
+            safety_class = configured
         else:
             inferred = infer_safety_class(spec)
             if inferred is not None:

--- a/src/weaver_kernel/drivers/mcp_classification.py
+++ b/src/weaver_kernel/drivers/mcp_classification.py
@@ -1,0 +1,91 @@
+"""Fail-closed safety classification for MCP tool discovery."""
+
+from __future__ import annotations
+
+import logging
+from typing import Literal
+
+from ..enums import SafetyClass
+from ..errors import DriverError
+from .mcp_support import ToolSpec
+
+logger = logging.getLogger("weaver_kernel.drivers.mcp")
+
+UnannotatedSafety = SafetyClass | Literal["reject"]
+"""How discovery handles a tool with no usable MCP safety annotation."""
+
+
+def infer_safety_class(spec: ToolSpec) -> SafetyClass | None:
+    """Infer safety only from explicit MCP annotation hints.
+
+    MCP annotations are advisory metadata, not authorization statements.
+    Destructive wins if a server supplies conflicting read/destructive hints.
+    Missing/ambiguous authority is represented as ``None`` rather than READ.
+    """
+    if spec.destructive_hint:
+        return SafetyClass.DESTRUCTIVE
+    if spec.read_only_hint:
+        return SafetyClass.READ
+    return None
+
+
+def classify_tool_specs(
+    specs: list[ToolSpec],
+    *,
+    driver_id: str,
+    safety_class_map: dict[str, SafetyClass] | None,
+    unannotated_safety: UnannotatedSafety,
+) -> list[tuple[ToolSpec, SafetyClass]]:
+    """Classify discovered MCP tools without silently granting unknown authority.
+
+    Explicit operator mappings take precedence over advisory MCP annotations.
+    Otherwise-unclassified tools are rejected by default; an explicit fallback
+    is allowed but logged with every affected tool name.
+    """
+    if unannotated_safety != "reject" and not isinstance(unannotated_safety, SafetyClass):
+        raise DriverError(
+            "unannotated_safety must be 'reject' or a SafetyClass, "
+            f"got {unannotated_safety!r}."
+        )
+
+    classified: list[tuple[ToolSpec, SafetyClass]] = []
+    rejected: list[str] = []
+    fallback: list[str] = []
+
+    for spec in specs:
+        if safety_class_map is not None and spec.name in safety_class_map:
+            safety_class = safety_class_map[spec.name]
+        else:
+            inferred = infer_safety_class(spec)
+            if inferred is not None:
+                safety_class = inferred
+            elif unannotated_safety == "reject":
+                rejected.append(spec.name)
+                continue
+            else:
+                safety_class = unannotated_safety
+                fallback.append(spec.name)
+        classified.append((spec, safety_class))
+
+    if rejected:
+        names = ", ".join(sorted(rejected))
+        raise DriverError(
+            f"MCPDriver '{driver_id}' refused to auto-register unclassified tools: {names}. "
+            "Classify them with safety_class_map or explicitly set unannotated_safety to a "
+            "SafetyClass. MCP annotations are advisory and missing metadata is not treated "
+            "as READ authority."
+        )
+
+    if fallback:
+        assert isinstance(unannotated_safety, SafetyClass)  # narrowed above
+        logger.warning(
+            "mcp_unannotated_safety_fallback driver_id=%s safety_class=%s tools=%s",
+            driver_id,
+            unannotated_safety.value,
+            ",".join(sorted(fallback)),
+        )
+
+    return classified
+
+
+__all__ = ["UnannotatedSafety", "classify_tool_specs", "infer_safety_class"]

--- a/src/weaver_kernel/drivers/mcp_classification.py
+++ b/src/weaver_kernel/drivers/mcp_classification.py
@@ -44,8 +44,7 @@ def classify_tool_specs(
     """
     if unannotated_safety != "reject" and not isinstance(unannotated_safety, SafetyClass):
         raise DriverError(
-            "unannotated_safety must be 'reject' or a SafetyClass, "
-            f"got {unannotated_safety!r}."
+            f"unannotated_safety must be 'reject' or a SafetyClass, got {unannotated_safety!r}."
         )
 
     classified: list[tuple[ToolSpec, SafetyClass]] = []

--- a/tests/test_mcp_discovery_safety.py
+++ b/tests/test_mcp_discovery_safety.py
@@ -87,6 +87,16 @@ async def test_explicit_safety_map_classifies_unannotated_tool() -> None:
 
 
 @pytest.mark.asyncio
+async def test_malformed_explicit_safety_map_fails_closed() -> None:
+    driver = _driver(_tool("delete_repo"))
+
+    with pytest.raises(DriverError, match=r"safety_class_map\['delete_repo'\]"):
+        await driver.discover(
+            safety_class_map={"delete_repo": "READ"},  # type: ignore[dict-item]
+        )
+
+
+@pytest.mark.asyncio
 async def test_explicit_unannotated_fallback_warns_and_names_tools(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -118,7 +128,7 @@ async def test_explicit_mcp_hints_still_infer_safety_class() -> None:
 
 
 @pytest.mark.asyncio
-async def test_invalid_unannotated_safety_fails_before_discovery() -> None:
+async def test_invalid_unannotated_safety_is_rejected() -> None:
     driver = _driver(_tool("list_files"))
 
     with pytest.raises(DriverError, match="unannotated_safety"):

--- a/tests/test_mcp_discovery_safety.py
+++ b/tests/test_mcp_discovery_safety.py
@@ -1,0 +1,125 @@
+"""Security-focused MCP discovery classification tests (#181)."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from weaver_kernel import DriverError, MCPDriver, SafetyClass
+
+
+class _Session:
+    def __init__(self, tools: list[Any]) -> None:
+        self._tools = tools
+
+    async def list_tools(self, cursor: str | None = None) -> Any:
+        return SimpleNamespace(tools=self._tools, nextCursor=None)
+
+
+def _factory(tools: list[Any]) -> Any:
+    @asynccontextmanager
+    async def factory() -> AsyncIterator[_Session]:
+        yield _Session(tools)
+
+    return factory
+
+
+def _tool(
+    name: str,
+    *,
+    read_only: bool = False,
+    destructive: bool = False,
+) -> Any:
+    annotations = None
+    if read_only or destructive:
+        annotations = SimpleNamespace(
+            readOnlyHint=read_only,
+            destructiveHint=destructive,
+            idempotentHint=False,
+        )
+    return SimpleNamespace(
+        name=name,
+        description=f"{name} tool",
+        annotations=annotations,
+        outputSchema=None,
+    )
+
+
+def _driver(*tools: Any) -> MCPDriver:
+    return MCPDriver(
+        driver_id="mcp:test",
+        session_factory=_factory(list(tools)),
+        server_name="test",
+        transport="stdio",
+    )
+
+
+@pytest.mark.asyncio
+async def test_unannotated_tools_are_rejected_by_default() -> None:
+    driver = _driver(_tool("list_files"), _tool("delete_repo"))
+
+    with pytest.raises(DriverError) as exc_info:
+        await driver.discover(namespace="repo")
+
+    message = str(exc_info.value)
+    assert "delete_repo" in message
+    assert "list_files" in message
+    assert "missing metadata is not treated as READ authority" in message
+
+
+@pytest.mark.asyncio
+async def test_explicit_safety_map_classifies_unannotated_tool() -> None:
+    driver = _driver(_tool("list_files"))
+
+    capabilities = await driver.discover(
+        namespace="repo",
+        safety_class_map={"list_files": SafetyClass.READ},
+    )
+
+    assert len(capabilities) == 1
+    assert capabilities[0].capability_id == "repo.list_files"
+    assert capabilities[0].safety_class is SafetyClass.READ
+
+
+@pytest.mark.asyncio
+async def test_explicit_unannotated_fallback_warns_and_names_tools(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    driver = _driver(_tool("send_email"), _tool("write_file"))
+
+    with caplog.at_level(logging.WARNING, logger="weaver_kernel.drivers.mcp"):
+        capabilities = await driver.discover(unannotated_safety=SafetyClass.WRITE)
+
+    assert {cap.safety_class for cap in capabilities} == {SafetyClass.WRITE}
+    assert "mcp_unannotated_safety_fallback" in caplog.text
+    assert "send_email" in caplog.text
+    assert "write_file" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_explicit_mcp_hints_still_infer_safety_class() -> None:
+    driver = _driver(
+        _tool("list_files", read_only=True),
+        _tool("delete_repo", destructive=True),
+    )
+
+    capabilities = await driver.discover()
+    by_name = {cap.name: cap.safety_class for cap in capabilities}
+
+    assert by_name == {
+        "list_files": SafetyClass.READ,
+        "delete_repo": SafetyClass.DESTRUCTIVE,
+    }
+
+
+@pytest.mark.asyncio
+async def test_invalid_unannotated_safety_fails_before_discovery() -> None:
+    driver = _driver(_tool("list_files"))
+
+    with pytest.raises(DriverError, match="unannotated_safety"):
+        await driver.discover(unannotated_safety="READ")  # type: ignore[arg-type]

--- a/tests/test_mcp_driver.py
+++ b/tests/test_mcp_driver.py
@@ -269,9 +269,7 @@ async def test_kernel_pipeline_with_discover_register_grant_invoke() -> None:
         transport="stdio",
     )
 
-    capabilities = await driver.discover(
-        safety_class_map={"math.sum": SafetyClass.READ}
-    )
+    capabilities = await driver.discover(safety_class_map={"math.sum": SafetyClass.READ})
     registry = CapabilityRegistry()
     registry.register_many(capabilities)
 

--- a/tests/test_mcp_driver.py
+++ b/tests/test_mcp_driver.py
@@ -134,7 +134,11 @@ async def test_discover_converts_tools_to_capabilities() -> None:
     )
 
     capabilities = await driver.discover(
-        namespace="fs", safety_class_map={"write_file": SafetyClass.WRITE}
+        namespace="fs",
+        safety_class_map={
+            "list_files": SafetyClass.READ,
+            "write_file": SafetyClass.WRITE,
+        },
     )
 
     assert [cap.capability_id for cap in capabilities] == [
@@ -265,7 +269,9 @@ async def test_kernel_pipeline_with_discover_register_grant_invoke() -> None:
         transport="stdio",
     )
 
-    capabilities = await driver.discover()
+    capabilities = await driver.discover(
+        safety_class_map={"math.sum": SafetyClass.READ}
+    )
     registry = CapabilityRegistry()
     registry.register_many(capabilities)
 
@@ -313,7 +319,10 @@ async def test_real_fastmcp_in_process_discover_and_execute() -> None:
         transport="stdio",
     )
 
-    capabilities = await driver.discover(namespace="math")
+    capabilities = await driver.discover(
+        namespace="math",
+        safety_class_map={"add": SafetyClass.READ},
+    )
     assert any(cap.capability_id == "math.add" for cap in capabilities)
     add_cap = next(c for c in capabilities if c.capability_id == "math.add")
     assert add_cap.impl is not None


### PR DESCRIPTION
Closes #181.

## What changed

- `MCPDriver.discover()` no longer silently classifies a tool with missing safety metadata as `SafetyClass.READ`.
- Default discovery now rejects any tool that lacks both an explicit `safety_class_map` entry and a useful MCP safety hint.
- Operators can deliberately choose `unannotated_safety=SafetyClass.WRITE|DESTRUCTIVE|READ`; every tool receiving that fallback is named in a warning.
- Explicit operator classifications remain highest precedence; destructive MCP hints beat read-only hints.
- Classification logic lives in a small `mcp_classification.py` helper rather than inflating the driver module.
- Existing MCP tests now classify intentionally unannotated fixtures explicitly.
- Added focused fail-closed regression tests and a migration/security guide.

## Why

The previous fallback was opposite to least privilege: absence of MCP metadata became the least-restricted safety class. MCP annotations are advisory and missing metadata is not evidence that an operation is read-only.

## Compatibility

Deliberate breaking security default. Previous behavior can be requested explicitly:

```python
await driver.discover(unannotated_safety=SafetyClass.READ)
```

The recommended migration is an operator-reviewed `safety_class_map`.

## Security boundary

This fixes missing-metadata classification. It does **not** make server-provided annotations trustworthy; a dishonest server can still mislabel a tool. High-assurance deployments should use reviewed operator classification.

## Validation

CI adds tests for:
- default rejection + affected tool names;
- explicit per-tool classification;
- explicit fallback + warning containing all affected tools;
- read/destructive hint inference;
- invalid fallback configuration;
- existing discover/register/invoke and real FastMCP fixtures updated to classify intentionally.

This PR should merge independently of the broader MCP v2 migration in #263; #173 remains the real-server interoperability gate.