### PR TITLE
test: encode Weaver invariants as an executable suite

### DIFF
--- a/docs/agent-context/invariants.md
+++ b/docs/agent-context/invariants.md
@@ -5,25 +5,44 @@
 
 ## Weaver-spec compliance
 
-agent-kernel must conform to [weaver-spec](https://github.com/dgenio/weaver-spec) invariants.
+Weaver Kernel must conform to [weaver-spec](https://github.com/dgenio/weaver-spec) invariants.
 All three are equally critical — there is no priority ordering.
 
 | Invariant | Requirement | Where enforced |
 |-----------|-------------|----------------|
-| **I-01** | Every tool output must pass through a context boundary before reaching the LLM | `Firewall.transform()` in `firewall/transform.py` |
-| **I-02** | Every execution must be authorized and auditable (CapabilityToken validated before execution; TraceEvent recorded after) | `HMACTokenProvider.verify()` + `TraceStore.record()` in `kernel.py`; `PolicyEngine.evaluate()` at grant time in `grant_capability()` |
-| **I-06** | Tokens must bind principal + capability + constraints; no reuse across principals | `HMACTokenProvider.verify()` in `tokens.py` |
+| **I-01** | Every tool output must pass through a context boundary before reaching the LLM-safe path | `Firewall.transform()` in `firewall/transform.py`, called by `kernel/_invoke.py` and streaming paths |
+| **I-02** | Every execution must be authorized and auditable (CapabilityToken validated before execution; ActionTrace recorded for the mediated run) | `HMACTokenProvider.verify()` in `tokens.py`; `Kernel.invoke()` / `kernel/_invoke.py`; trace stores |
+| **I-06** | Tokens must bind principal + capability + constraints; no reuse across principals | `CapabilityToken` signed payload + `HMACTokenProvider.verify()` in `tokens.py` |
 
 > **Budget enforcement** (size, depth, field count via `Budgets` in `firewall/budgets.py`) is an
 > implementation constraint that strengthens I-01. It has no separate invariant number in weaver-spec.
+
+## Executable invariant suite
+
+The named architecture-level regression suite is [`tests/test_invariants.py`](../../tests/test_invariants.py).
+It contains at least three black-box/component tests for each current Weaver invariant:
+
+- **I-01:** non-admin raw downgrade/redaction, signed allowed-field projection, and handle-only payload isolation;
+- **I-02:** invalid authority cannot reach a driver, successful execution has an explainable trace, and driver failure is still audited;
+- **I-06:** cross-principal rejection, cross-capability rejection, and signature failure after constraint widening.
+
+These tests intentionally overlap some specialist suites (`test_firewall_boundary.py`, `test_policy_properties.py`, token tests). The overlap is deliberate: an architectural invariant should fail in a file whose name makes the broken promise obvious during review.
+
+Run only the named suite with:
+
+```bash
+pytest -q tests/test_invariants.py
+```
+
+Property-based/adversarial coverage remains in `tests/test_policy_properties.py`; the named suite is the compact executable specification, not a replacement for deeper fuzz/property testing.
 
 ## Forbidden shortcuts — "never do" list
 
 These constraints are non-negotiable. Violating any one silently degrades security.
 
 1. **Never bypass the Firewall.** `RawResult → Frame` transformation is mandatory.
-   Raw driver output must never reach the LLM (except via admin `raw` mode, which
-   the Firewall itself controls).
+   Raw driver output must never reach the LLM-safe path (except via admin `raw` mode,
+   which the Firewall itself still processes/redacts).
 
 2. **Never skip token verification before invocation.** `Kernel.invoke()` always calls
    `verify()` first. Removing or short-circuiting this check defeats confused-deputy
@@ -31,7 +50,7 @@ These constraints are non-negotiable. Violating any one silently degrades securi
 
 3. **Never allow non-admin principals to get `raw` response mode.** The Firewall
    downgrades `raw` to `summary` for non-admin principals. Any code path that bypasses
-   this check leaks unbounded, unredacted data.
+   this check leaks unbounded or inappropriate data.
 
 4. **Never store secrets in token payloads.** Tokens are HMAC-signed but not encrypted.
    Payload contents are readable by anyone who holds the token.
@@ -53,12 +72,14 @@ These are subtle correctness hazards where the code is correct today but a carel
 change introduces a silent bypass.
 
 ### Policy rule ordering
+
 `DefaultPolicyEngine.evaluate()` processes rules sequentially. Adding a new "allow"
 rule before sensitivity/justification checks can silently bypass them. Always add
 new rules **after** existing sensitivity checks, or verify that the new rule's
 position does not short-circuit downstream checks.
 
 ### SensitivityTag coverage
+
 `evaluate()` only checks `SensitivityTag` values it knows about. Adding a new tag to
 the `SensitivityTag` enum without a corresponding rule in `evaluate()` means the new
 tag is **silently ignored** — capabilities tagged with it pass policy without constraint.
@@ -66,13 +87,13 @@ tag is **silently ignored** — capabilities tagged with it pass policy without 
 **Rule:** When adding a `SensitivityTag`, always add a matching policy rule and test.
 
 ### Dry-run response-mode parity
+
 `Kernel.invoke(dry_run=True)` reports the response mode the caller would actually
 get at real-invoke time. The Firewall downgrades `raw` to `summary` for non-admin
-principals (`firewall/transform.py:108`), so dry-run must mirror that downgrade —
-otherwise a non-admin caller can probe/assume raw-mode availability they will never
-actually receive. The same applies to `operation`: dry-run resolves it the same way
-drivers do (`args.get("operation", capability_id)`), so what the caller sees in
-`DryRunResult` matches what a driver would receive.
+principals, so dry-run must mirror that downgrade — otherwise a non-admin caller
+can probe/assume raw-mode availability they will never actually receive. The same
+applies to `operation`: dry-run resolves it the same way drivers do
+(`args.get("operation", capability_id)`).
 
 **Rule:** Any code path that reports a response mode or driver operation back to the
 caller must apply the same admin gate / resolution rule the real-invoke path uses,
@@ -88,6 +109,8 @@ including dry-run, mock, and test paths.
 | Adding error subclasses | Raising bare `ValueError`/`KeyError` to callers |
 
 ## Update triggers for this file
+
 - A weaver-spec invariant is added, changed, or reinterpreted.
 - A new "never do" constraint is discovered through review or incident.
 - A new security-critical ordering trap is identified.
+- The named invariant suite changes which behavior is treated as architecturally load-bearing.

--- a/tests/test_invariants.py
+++ b/tests/test_invariants.py
@@ -1,0 +1,233 @@
+"""Named executable suite for Weaver invariants I-01, I-02 and I-06 (#199).
+
+These tests intentionally use the public Kernel/token/firewall-facing APIs where
+possible. Their job is architectural: a refactor that breaks a documented Weaver
+invariant should fail a file named ``test_invariants.py`` loudly, even when more
+specialized tests elsewhere still pass.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+
+from weaver_kernel import (
+    Capability,
+    CapabilityRegistry,
+    DriverError,
+    HMACTokenProvider,
+    InMemoryDriver,
+    Kernel,
+    Principal,
+    SafetyClass,
+    StaticRouter,
+    TokenInvalid,
+    TokenScopeError,
+    TraceStore,
+)
+
+_CAPABILITY_ID = "records.read"
+_SECRET = "named-invariant-suite-secret"
+_SENTINEL = "Bearer INVARIANT-SENTINEL-DO-NOT-LEAK"
+
+
+def _build_kernel(
+    result_factory: Callable[[], Any],
+    *,
+    constraints: dict[str, Any] | None = None,
+) -> tuple[
+    Kernel,
+    HMACTokenProvider,
+    TraceStore,
+    Principal,
+    Any,
+    list[str],
+]:
+    registry = CapabilityRegistry()
+    registry.register(
+        Capability(
+            capability_id=_CAPABILITY_ID,
+            name="Read records",
+            description="Invariant-suite fixture",
+            safety_class=SafetyClass.READ,
+        )
+    )
+
+    calls: list[str] = []
+    driver = InMemoryDriver(driver_id="fixture")
+
+    def handler(_ctx: object) -> Any:
+        calls.append(_CAPABILITY_ID)
+        return result_factory()
+
+    driver.register_handler(_CAPABILITY_ID, handler)
+    provider = HMACTokenProvider(secret=_SECRET)
+    traces = TraceStore()
+    kernel = Kernel(
+        registry=registry,
+        token_provider=provider,
+        router=StaticRouter(routes={_CAPABILITY_ID: ["fixture"]}),
+        trace_store=traces,
+    )
+    kernel.register_driver(driver)
+    principal = Principal(principal_id="alice", roles=["reader"])
+    token = provider.issue(
+        _CAPABILITY_ID,
+        principal.principal_id,
+        constraints=constraints,
+    )
+    return kernel, provider, traces, principal, token, calls
+
+
+# I-01 — every tool result crosses the context boundary before LLM-safe output.
+
+
+@pytest.mark.asyncio
+async def test_i01_non_admin_raw_request_is_bounded_and_redacted() -> None:
+    """I-01: a non-admin cannot turn a raw request into raw driver output."""
+    kernel, _provider, _traces, principal, token, _calls = _build_kernel(
+        lambda: [{"id": 1, "authorization": _SENTINEL}]
+    )
+
+    frame = await kernel.invoke(token, principal=principal, args={}, response_mode="raw")
+
+    assert frame.response_mode == "summary"
+    assert frame.raw_data is None
+    assert _SENTINEL not in repr(frame)
+
+
+@pytest.mark.asyncio
+async def test_i01_allowed_fields_cannot_be_widened_by_driver_output() -> None:
+    """I-01: signed field constraints bound the LLM-safe table projection."""
+    kernel, _provider, _traces, principal, token, _calls = _build_kernel(
+        lambda: [{"id": 1, "internal": "must-not-cross-boundary"}],
+        constraints={"allowed_fields": ["id"]},
+    )
+
+    frame = await kernel.invoke(token, principal=principal, args={}, response_mode="table")
+
+    assert frame.table_preview == [{"id": 1}]
+    assert "must-not-cross-boundary" not in repr(frame)
+
+
+@pytest.mark.asyncio
+async def test_i01_handle_only_exposes_reference_not_driver_payload() -> None:
+    """I-01: handle-only mode returns a reference without inline result data."""
+    kernel, _provider, _traces, principal, token, _calls = _build_kernel(
+        lambda: [{"id": 1, "secret": _SENTINEL}]
+    )
+
+    frame = await kernel.invoke(
+        token,
+        principal=principal,
+        args={},
+        response_mode="handle_only",
+    )
+
+    assert frame.handle is not None
+    assert frame.table_preview == []
+    assert frame.facts == []
+    assert frame.raw_data is None
+    assert _SENTINEL not in repr(frame)
+
+
+# I-02 — no execution without verified authority; executions are auditable.
+
+
+@pytest.mark.asyncio
+async def test_i02_invalid_token_never_reaches_driver() -> None:
+    """I-02: verification failure occurs before the driver is called."""
+    kernel, _provider, _traces, principal, token, calls = _build_kernel(lambda: [{"ok": True}])
+    token.signature = "0" * len(token.signature)
+
+    with pytest.raises(TokenInvalid):
+        await kernel.invoke(token, principal=principal, args={})
+
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_i02_successful_execution_has_explainable_trace() -> None:
+    """I-02: a successful mediated execution leaves one explainable receipt."""
+    kernel, _provider, traces, principal, token, calls = _build_kernel(
+        lambda: [{"id": 1, "status": "ok"}]
+    )
+
+    frame = await kernel.invoke(token, principal=principal, args={})
+    trace = kernel.explain(frame.action_id)
+
+    assert calls == [_CAPABILITY_ID]
+    assert trace.capability_id == _CAPABILITY_ID
+    assert trace.principal_id == principal.principal_id
+    assert trace.error is None
+    assert len(traces.list_all()) == 1
+
+
+@pytest.mark.asyncio
+async def test_i02_driver_failure_is_still_audited() -> None:
+    """I-02: once execution starts, driver failure cannot escape untraced."""
+
+    def fail() -> Any:
+        raise RuntimeError("synthetic driver failure")
+
+    kernel, _provider, traces, principal, token, calls = _build_kernel(fail)
+
+    with pytest.raises(DriverError):
+        await kernel.invoke(token, principal=principal, args={})
+
+    assert calls == [_CAPABILITY_ID]
+    recorded = traces.list_all()
+    assert len(recorded) == 1
+    assert recorded[0].capability_id == _CAPABILITY_ID
+    assert recorded[0].principal_id == principal.principal_id
+    assert recorded[0].error is not None
+    assert "synthetic driver failure" in recorded[0].error
+
+
+# I-06 — signed grants bind principal + capability + constraints.
+
+
+def test_i06_token_cannot_cross_principal_boundary() -> None:
+    """I-06: a token minted for Alice cannot authorize Bob."""
+    provider = HMACTokenProvider(secret=_SECRET)
+    token = provider.issue(_CAPABILITY_ID, "alice")
+
+    with pytest.raises(TokenScopeError):
+        provider.verify(
+            token,
+            expected_principal_id="bob",
+            expected_capability_id=_CAPABILITY_ID,
+        )
+
+
+def test_i06_token_cannot_cross_capability_boundary() -> None:
+    """I-06: a grant for one capability cannot authorize another."""
+    provider = HMACTokenProvider(secret=_SECRET)
+    token = provider.issue(_CAPABILITY_ID, "alice")
+
+    with pytest.raises(TokenScopeError):
+        provider.verify(
+            token,
+            expected_principal_id="alice",
+            expected_capability_id="records.delete",
+        )
+
+
+def test_i06_mutating_signed_constraints_invalidates_token() -> None:
+    """I-06: constraints are inside the signed payload and cannot be widened."""
+    provider = HMACTokenProvider(secret=_SECRET)
+    token = provider.issue(
+        _CAPABILITY_ID,
+        "alice",
+        constraints={"allowed_fields": ["id"]},
+    )
+    token.constraints["allowed_fields"] = ["id", "secret"]
+
+    with pytest.raises(TokenInvalid):
+        provider.verify(
+            token,
+            expected_principal_id="alice",
+            expected_capability_id=_CAPABILITY_ID,
+        )


### PR DESCRIPTION
Closes #199.

## What changed

Adds a named `tests/test_invariants.py` executable specification for the three current Weaver invariants, with three focused tests per invariant:

### I-01 — context boundary
- non-admin `raw` requests downgrade and cannot expose the raw sentinel;
- signed `allowed_fields` constraints bound table output;
- `handle_only` exposes a reference rather than inline driver payload.

### I-02 — authorized + auditable execution
- invalid/tampered authority fails before the driver executes;
- successful execution has an `explain()`-retrievable ActionTrace;
- driver failure still produces an audit record.

### I-06 — scoped token binding
- cross-principal verification fails;
- cross-capability verification fails;
- widening signed constraints after issuance invalidates the token signature.

Also updates `docs/agent-context/invariants.md` to point directly at the named suite and correct the implementation-location references to the current split `kernel/` modules.

## Why

The repo already has strong specialist coverage (`test_firewall_boundary.py`, `test_policy_properties.py`, token tests). This PR does not replace it. It makes the architecture promise impossible to miss: a refactor that breaks I-01/I-02/I-06 should fail a compact file literally named `test_invariants.py`.

#245 was separately closed as already satisfied by the existing Hypothesis property suite; this PR supplies the distinct named executable-specification layer #199 requested.

## Validation

No runtime code changed. The new tests use public Kernel/token APIs where possible and should run in the normal CI matrix.