### PR TITLE
community: add security and contribution health files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,78 @@
+name: Bug report
+description: Report a reproducible problem in Weaver Kernel
+title: "bug: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve Weaver Kernel. If this may be a security vulnerability, **do not continue here**; use the private security-reporting link in the issue chooser instead.
+  - type: input
+    id: version
+    attributes:
+      label: Weaver Kernel version / commit
+      description: Package version (for example 0.x.y) or exact commit SHA.
+      placeholder: "0.x.y or commit SHA"
+    validations:
+      required: true
+  - type: input
+    id: python
+    attributes:
+      label: Python version
+      placeholder: "3.12.x"
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Kernel / invocation
+        - Policy / authorization
+        - Capability tokens / constraints
+        - Context Firewall / Frames / handles
+        - MCP integration
+        - Other integration / adapter
+        - Audit / traces
+        - Packaging / installation
+        - Documentation
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Minimal reproduction
+      description: Prefer the smallest runnable snippet or test that demonstrates the problem. Remove credentials and real sensitive data.
+      render: python
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect Kernel to do?
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: Include the exact exception/reason code/output when useful.
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Integration / environment details
+      description: Relevant SDK versions, transport (stdio/HTTP), OS, framework, worker count, or deployment assumptions.
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched existing open and closed issues for the same problem.
+          required: true
+        - label: This report does not contain credentials, customer data, or other secrets.
+          required: true
+        - label: I read the Security Contract if this concerns an enforcement/security boundary.
+          required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Report a security vulnerability privately
+    url: https://github.com/dgenio/agent-kernel/security/advisories/new
+    about: Do not disclose suspected vulnerabilities in a public issue. Use a private GitHub Security Advisory.
+  - name: Read the Security Contract first
+    url: https://github.com/dgenio/agent-kernel/blob/main/docs/security-contract.md
+    about: Check the guarantees and explicit non-goals before reporting a security-boundary mismatch.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,53 @@
+name: Feature request
+description: Propose a problem worth solving in Weaver Kernel
+title: "proposal: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Weaver Kernel uses a gate-driven roadmap. Please lead with the **user/security problem and evidence**, not only a desired API. Speculative platform expansion may be closed until adopter pull exists.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What concrete problem cannot be solved adequately with the current Kernel, the host framework, or an existing IAM/policy system?
+    validations:
+      required: true
+  - type: textarea
+    id: users
+    attributes:
+      label: Who needs this?
+      description: Describe the real adopter/use case. Links to downstream code or reproducible examples are especially useful.
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence / current workaround
+      description: What have you tried? What fails or becomes unsafe/expensive today?
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Smallest useful change
+      description: What is the narrowest change that would solve the problem without broadening Kernel into a general agent platform?
+    validations:
+      required: true
+  - type: textarea
+    id: security
+    attributes:
+      label: Security / compatibility impact
+      description: Does this change a principal, capability, constraint, execution, output, audit, protocol, or deployment guarantee? Could it introduce a fail-open path?
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Include native framework controls, external IAM/policy, AgentFence/gateway, or doing nothing when relevant.
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched open and closed issues for related work.
+          required: true
+        - label: I read ROADMAP.md and understand this may be deferred if it is Gate-7 expansion without adopter pull.
+          required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,36 @@
+## What changed
+
+<!-- Describe the smallest logical change in this PR. -->
+
+## Why
+
+<!-- Link the issue/user/security evidence. Explain why this belongs on the current roadmap. -->
+
+## Security / contract impact
+
+- [ ] No security/public-contract impact
+- [ ] Changes a principal / policy / capability / token / constraint path
+- [ ] Changes execution or driver mediation
+- [ ] Changes Firewall / Frame / handle behavior
+- [ ] Changes audit / trace / evidence behavior
+- [ ] Changes protocol/framework compatibility or coverage
+- [ ] Changes the Security Contract or a documented non-goal
+
+<!-- If any box other than “No impact” applies, explain the invariant/claim and the fail-closed behavior. -->
+
+## Compatibility / migration
+
+<!-- State whether this is additive, behavior-changing, deprecated, or breaking. Link docs/versioning.md and include a migration path for supported behavior changes. -->
+
+## Validation
+
+- [ ] `make ci` passes on the exact PR head
+- [ ] Tests cover the behavior change, including a negative/fail-closed case when security-sensitive
+- [ ] I checked whether `tests/test_invariants.py` or `tests/test_policy_properties.py` should change
+- [ ] Documentation matches implementation
+- [ ] CHANGELOG/release notes are updated when user-visible behavior or compatibility changes
+- [ ] New dependency/protocol ranges are justified by tested compatibility, not speculative version widening
+
+## Review notes
+
+<!-- Call out risky files, known limitations, follow-ups, or intentionally unsupported surfaces. -->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,43 @@
+# Code of Conduct
+
+We want Weaver Kernel to be a technically rigorous, welcoming open-source project where disagreement is useful and participation is safe.
+
+## Expected behavior
+
+Participants should:
+
+- treat other contributors with respect, including when reviewing or rejecting ideas;
+- critique code, claims and designs rather than people;
+- make room for different levels of experience and different technical backgrounds;
+- state uncertainty and evidence honestly, especially for security claims;
+- assume good faith while still reviewing security-sensitive changes critically;
+- avoid harassment, discrimination, threats, sexualized attention, doxxing, stalking, or sustained personal attacks;
+- respect a contributor's decision to disengage from a conversation.
+
+Technical disagreement is welcome. Strong criticism of a design is not a conduct violation when it remains focused on the work and is expressed professionally.
+
+## Scope
+
+This code applies in repository issues, pull requests, reviews, security advisories, and other project spaces, as well as when someone is publicly representing the project.
+
+## Reporting conduct concerns
+
+Do not force a reporter to disclose a sensitive conduct concern in a public issue.
+
+Until the project has a dedicated private conduct mailbox, use the repository's private GitHub advisory channel as the confidential maintainer contact:
+
+`https://github.com/dgenio/agent-kernel/security/advisories/new`
+
+Prefix the advisory title with **`[Conduct]`** so it is triaged as a conduct report rather than a vulnerability report. Do not include unrelated credentials or sensitive production data.
+
+If a report concerns the repository maintainer directly and the reporter does not consider that channel appropriate, use GitHub's platform abuse/reporting mechanisms instead.
+
+## Enforcement
+
+Maintainers may edit or remove comments, decline contributions, issue a warning, temporarily restrict participation, or permanently ban participation when behavior materially violates this code. Enforcement should be proportionate, documented privately where appropriate, and avoid disclosing information a reporter expected to remain confidential.
+
+Retaliation against someone for making a good-faith report is itself unacceptable.
+
+## Attribution
+
+This policy follows the principles and enforcement intent of widely used open-source contributor codes of conduct, including the Contributor Covenant, while keeping the project-specific reporting route explicit.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -22,22 +22,22 @@ This code applies in repository issues, pull requests, reviews, security advisor
 
 ## Reporting conduct concerns
 
-Do not force a reporter to disclose a sensitive conduct concern in a public issue.
+Do not disclose sensitive conduct concerns through the vulnerability-reporting channel. GitHub Security Advisories are reserved for security vulnerabilities.
 
-Until the project has a dedicated private conduct mailbox, use the repository's private GitHub advisory channel as the confidential maintainer contact:
+The project does not currently publish a dedicated private conduct mailbox. Until one exists:
 
-`https://github.com/dgenio/agent-kernel/security/advisories/new`
+- use GitHub's platform **Report abuse / Report content** mechanisms for harassment, threats, doxxing, discrimination, or other concerns that should be handled privately by the platform;
+- for non-sensitive project-moderation concerns, a concise public issue/comment may be appropriate when the reporter is comfortable doing so;
+- if the concern involves the repository maintainer, prefer GitHub's platform reporting route rather than asking that maintainer to privately adjudicate the complaint.
 
-Prefix the advisory title with **`[Conduct]`** so it is triaged as a conduct report rather than a vulnerability report. Do not include unrelated credentials or sensitive production data.
-
-If a report concerns the repository maintainer directly and the reporter does not consider that channel appropriate, use GitHub's platform abuse/reporting mechanisms instead.
+This limitation is intentional and transparent: the project should not pretend a private conduct channel exists when it does not. A dedicated project contact can replace this section later if one is established.
 
 ## Enforcement
 
-Maintainers may edit or remove comments, decline contributions, issue a warning, temporarily restrict participation, or permanently ban participation when behavior materially violates this code. Enforcement should be proportionate, documented privately where appropriate, and avoid disclosing information a reporter expected to remain confidential.
+Maintainers may edit or remove comments, decline contributions, issue a warning, temporarily restrict participation, or permanently ban participation when behavior materially violates this code. Enforcement should be proportionate and should avoid amplifying information a reporter expected to remain sensitive.
 
 Retaliation against someone for making a good-faith report is itself unacceptable.
 
 ## Attribution
 
-This policy follows the principles and enforcement intent of widely used open-source contributor codes of conduct, including the Contributor Covenant, while keeping the project-specific reporting route explicit.
+This policy follows the principles and enforcement intent of widely used open-source contributor codes of conduct, including the Contributor Covenant, while keeping the project's current reporting limitations explicit.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,83 @@
+# Security Policy
+
+Weaver Kernel sits on an agent-action enforcement boundary, so responsible vulnerability reporting is especially valuable.
+
+## Supported versions
+
+Security fixes are prioritized for the **latest published release** and current `main`.
+
+| Version | Security support |
+| --- | --- |
+| Latest published release | Supported |
+| Current `main` / unreleased next version | Fixes developed here before release |
+| Older published releases | Best effort; reporters may be asked to reproduce on the latest release |
+
+A security fix may require a fail-closed behavior change even when that is breaking. See [`docs/versioning.md`](docs/versioning.md) for the compatibility policy and [`docs/security-contract.md`](docs/security-contract.md) for the guarantees Kernel currently claims.
+
+## Report a vulnerability privately
+
+**Do not open a public issue for a suspected vulnerability.**
+
+Use GitHub's private repository-security channel:
+
+1. Open the repository's **Security** tab.
+2. Choose **Advisories** / **Report a vulnerability** (wording depends on your GitHub permissions/UI).
+3. Create a private draft advisory with the report.
+
+Direct link when available:
+
+`https://github.com/dgenio/agent-kernel/security/advisories/new`
+
+Include, where possible:
+
+- affected Weaver Kernel version or commit SHA;
+- affected integration/deployment mode (for example MCP stdio, MCP HTTP, embedded wrapper);
+- a minimal reproducer or failing test;
+- the security property you expected to hold;
+- whether driver/tool execution actually occurred;
+- whether the issue crosses a principal, capability, constraint, output, audit, or deployment-consistency boundary;
+- any suggested remediation, if you have one.
+
+Please avoid including real credentials, secrets, customer data, or destructive production steps. A synthetic reproducer is strongly preferred.
+
+## Response expectations
+
+This is an open-source project, not a staffed security service and there is no contractual SLA. Maintainers nevertheless aim to:
+
+- acknowledge a well-formed private report within **7 calendar days**;
+- confirm whether the report reproduces or request additional detail;
+- coordinate disclosure timing for confirmed vulnerabilities;
+- credit reporters when they want attribution and disclosure is appropriate.
+
+Complex fixes can take longer, particularly when they affect protocol compatibility or public security contracts. The maintainer will prefer an accurate fix and explicit limitation over a rushed claim that the issue is resolved.
+
+## Security scope
+
+High-value reports include, but are not limited to:
+
+- a Kernel-mediated driver executing without valid authorization;
+- a capability token being usable by a different principal or capability;
+- signed constraints being widened or bypassed;
+- malformed security configuration causing a fail-open path;
+- raw/sensitive driver output bypassing the documented Context Firewall boundary;
+- handle expansion escaping the original grant/principal constraints;
+- audit/evidence paths leaking raw secrets or omitting an execution that the contract says must be recorded;
+- protocol/integration behavior that silently weakens an advertised enforcement guarantee;
+- concurrency or state-consistency behavior that violates a documented supported deployment profile.
+
+## Important non-vulnerabilities / non-goals
+
+Please read the [Security Contract](docs/security-contract.md) before reporting a boundary mismatch. In particular, Weaver Kernel currently does **not** claim:
+
+- to make an LLM trustworthy;
+- to prevent execution paths that bypass the in-process Kernel mediation point;
+- to be a VM/container/network sandbox;
+- to authenticate a `Principal` on behalf of the host;
+- to provide globally consistent revocation/rate-limit/handle state across independent workers unless the deployed backing state establishes that property;
+- to make heuristic PII/secret redaction a formal confidentiality proof.
+
+A surprising result inside one of those non-goals can still be worth discussing, but it may be a product/design issue rather than a vulnerability.
+
+## Public security issues
+
+Once a vulnerability is fixed/disclosed, public follow-up work may be tracked in normal issues when doing so no longer exposes an unpatched weakness. Security-sensitive implementation details should stay in the private advisory until coordinated disclosure.


### PR DESCRIPTION
Progresses #144.

## What changed

Adds the community-health surfaces that matter most for a security-sensitive OSS library:

- `SECURITY.md`
  - private GitHub Security Advisory reporting route for vulnerabilities;
  - supported-version policy;
  - requested reproducer/evidence fields;
  - response expectations without pretending there is a staffed SLA;
  - explicit vulnerability scope + security-contract non-goals.
- `CODE_OF_CONDUCT.md`
  - concise project conduct expectations;
  - explicitly keeps conduct reporting separate from Security Advisories;
  - uses GitHub platform reporting for sensitive harassment/abuse concerns until a dedicated private project contact exists;
  - transparently states that the repo does not currently publish a dedicated private conduct mailbox.
- structured GitHub issue forms for bugs and feature proposals;
  - bug form diverts vulnerabilities to the private security channel;
  - proposal form requires user/problem evidence and acknowledges the gate-driven roadmap.
- issue-template config with private security/reporting + Security Contract links.
- security-aware pull-request template requiring compatibility/migration thinking, fail-closed tests and exact protocol/version evidence.

I also curated existing open issues #215, #220 and #186 with the repo's existing `good-first-ai-issue` label rather than inventing trivial contribution work.

## Why

A security library should not ask reporters to disclose vulnerabilities publicly, and an adoption-focused OSS repo should help contributors distinguish actionable problems from speculative platform expansion.

## Deliberate limitations

- This does not enable GitHub Discussions because repository-settings mutation is not exposed by the connected GitHub tool.
- It uses the existing `good-first-ai-issue` label because that label already exists; no new label-management surface is assumed.
- No fake private conduct channel is invented; GitHub platform reporting is documented until a dedicated project contact exists.
- `SECURITY.md` links `docs/versioning.md`, so merge this after the stability-policy PR #282.

## Validation

Repository metadata/docs only; no runtime code. CI should still validate repository formatting/link assumptions where configured.